### PR TITLE
Luis's Updates merge

### DIFF
--- a/include/Multislice_calcOutput.h
+++ b/include/Multislice_calcOutput.h
@@ -42,12 +42,14 @@ namespace Prismatic{
 	void formatOutput_CPU_integrate(Parameters<PRISMATIC_FLOAT_PRECISION>& pars,
 	                                Array2D< complex<PRISMATIC_FLOAT_PRECISION> >& psi,
 	                                const Array2D<PRISMATIC_FLOAT_PRECISION> &alphaInd,
+									const size_t currentSlice,
 	                                const size_t ay,
 	                                const size_t ax);
 
 	void formatOutput_CPU_integrate_batch(Parameters<PRISMATIC_FLOAT_PRECISION>& pars,
 	                                      Array1D< complex<PRISMATIC_FLOAT_PRECISION> >& psi_stack,
 	                                      const Array2D<PRISMATIC_FLOAT_PRECISION> &alphaInd,
+										  const size_t currentSlice,
 	                                      const size_t ay,
 	                                      const size_t ax);
 

--- a/include/configure.h
+++ b/include/configure.h
@@ -41,6 +41,7 @@ namespace Prismatic {
 	using format_output_func = void (*)( Parameters<PRISMATIC_FLOAT_PRECISION>&,
 	                                     Array2D< std::complex<PRISMATIC_FLOAT_PRECISION> >&,
 	                                     const Array2D<PRISMATIC_FLOAT_PRECISION>&,
+										 const size_t,
 	                                     const size_t,
 	                                     const size_t);
 	using fill_Scompact_func = void(*)(Parameters<PRISMATIC_FLOAT_PRECISION> &pars);
@@ -58,6 +59,7 @@ namespace Prismatic {
 	                                        PRISMATIC_FLOAT_PRECISION*,
 	                                        const size_t,
 	                                        const size_t,
+											const size_t,
 	                                        const size_t&,
 	                                        const size_t&,
 	                                        const cudaStream_t&,

--- a/include/meta.h
+++ b/include/meta.h
@@ -82,6 +82,7 @@ namespace Prismatic{
 			save3DOutput          = true;
 			save4DOutput          = false;
 			saveRealSpaceCoords   = false;
+			savePotentialSlices   = false;
 			userSpecifiedCelldims = false;
 			realSpaceWindow_x     = false;
 			realSpaceWindow_y     = false;
@@ -140,6 +141,7 @@ namespace Prismatic{
 		bool save3DOutput;
 		bool save4DOutput;
 		bool saveRealSpaceCoords;
+		bool savePotentialSlices;
 		bool userSpecifiedCelldims;
 		bool realSpaceWindow_x;
 		bool realSpaceWindow_y;
@@ -236,6 +238,11 @@ namespace Prismatic{
 		} else {
 			std::cout << "saveRealSpaceCoords = false" << std::endl;
 		}
+		if (savePotentialSlices) {
+			std::cout << "savePotentialSlices = true" << std::endl;
+		} else {
+			std::cout << "savePotentialSlices= false" << std::endl;
+		}
 
 
 #ifdef PRISMATIC_ENABLE_GPU
@@ -299,6 +306,7 @@ namespace Prismatic{
 		if(save3DOutput != other.save3DOutput)return false;
 		if(save4DOutput != other.save4DOutput)return false;
 		if(saveRealSpaceCoords != other.saveRealSpaceCoords)return false;
+		if(savePotentialSlices != other.savePotentialSlices)return false;
 		if(userSpecifiedCelldims != other.userSpecifiedCelldims)return false;
 		if(realSpaceWindow_x != other.realSpaceWindow_x)return false;
 		if(realSpaceWindow_y != other.realSpaceWindow_y)return false;

--- a/include/meta.h
+++ b/include/meta.h
@@ -37,9 +37,9 @@ namespace Prismatic{
 			realspacePixelSize[1] = 0.1;
 			potBound              = 2.0;
 			numFP                 = 1;
-            fpNum                 = 1;
+			fpNum                 = 1;
 			sliceThickness        = 2.0;
-			numSlices		      = 0; 
+			numSlices             = 0; 
 			zStart                = 0.0;
 			cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
 			tileX                 = 1;
@@ -52,10 +52,10 @@ namespace Prismatic{
 			numThreads            = 12;
 			batchSizeTargetCPU    = 1;
 			batchSizeTargetGPU    = 1;
-			batchSizeCPU 		  = batchSizeTargetCPU;
+			batchSizeCPU          = batchSizeTargetCPU;
 			batchSizeGPU          = batchSizeTargetGPU;
 			earlyCPUStopCount     = 100; // relative speed of job completion between gpu and cpu, used to determine early stopping point for cpu work
-            probeStepX            = 0.25;
+			probeStepX            = 0.25;
 			probeStepY            = 0.25;
 			probeDefocus          = 0.0;
 			C3                    = 0.0;
@@ -68,8 +68,8 @@ namespace Prismatic{
 			scanWindowXMax        = 0.99999;
 			scanWindowYMin        = 0.0;
 			scanWindowYMax        = 0.99999;
-			scanWindowXMin_r	  = 0.0; //realspace alternatives to setting scan window
-			scanWindowXMax_r	  = 0.0;
+			scanWindowXMin_r      = 0.0; //realspace alternatives to setting scan window
+			scanWindowXMax_r      = 0.0;
 			scanWindowYMin_r      = 0.0;
 			scanWindowYMax_r      = 0.0;
 			srand(time(0));
@@ -81,10 +81,10 @@ namespace Prismatic{
 			save2DOutput          = false;
 			save3DOutput          = true;
 			save4DOutput          = false;
-			saveRealSpaceCoords	  = false;
+			saveRealSpaceCoords   = false;
 			userSpecifiedCelldims = false;
-			realSpaceWindow_x	  = false;
-			realSpaceWindow_y	  = false;
+			realSpaceWindow_x     = false;
+			realSpaceWindow_y     = false;
 			integrationAngleMin   = 0;
 			integrationAngleMax   = detectorAngleStep;
 			transferMode          = StreamingMode::Auto;

--- a/include/meta.h
+++ b/include/meta.h
@@ -39,7 +39,8 @@ namespace Prismatic{
 			numFP                 = 1;
             fpNum                 = 1;
 			sliceThickness        = 2.0;
-			numSlices		      = 0; //to give a logic check, so that intermediate output only given when positive integer is given
+			numSlices		      = 0; 
+			zStart                = 0.0;
 			cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
 			tileX                 = 1;
 			tileY                 = 1;
@@ -91,6 +92,7 @@ namespace Prismatic{
 		size_t fpNum; // current frozen phonon number
 		T sliceThickness; // thickness of slice in Z
 		size_t numSlices; //number of slices to itereate through in multislice before giving an output
+		T zStart; //Z coordinate of cell where multislice intermediate output will begin outputting
 		T probeStepX;
 		T probeStepY;
 		std::vector<T> cellDim; // this is z,y,x format
@@ -152,6 +154,7 @@ namespace Prismatic{
 		std::cout << "numFP = " << numFP << std::endl;
 		std::cout << "sliceThickness = " << sliceThickness<< std::endl;
 		std::cout << "numSlices = " << numSlices << std::endl;
+		std::cout << "zStart = " << zStart << std::endl;
  		std::cout << "E0 = " << E0 << std::endl;
 		std::cout << "alphaBeamMax = " << alphaBeamMax << std::endl;
 		std::cout << "numThreads = " << numThreads<< std::endl;
@@ -239,6 +242,7 @@ namespace Prismatic{
 		if(numFP != other.numFP)return false;
 		if(sliceThickness != other.sliceThickness)return false;
 		if(numSlices != other.numSlices)return false;
+		if(zStart != other.zStart)return false;
 		if(cellDim[0] != other.cellDim[0])return false;
 		if(cellDim[1] != other.cellDim[1])return false;
 		if(cellDim[2] != other.cellDim[2])return false;

--- a/include/meta.h
+++ b/include/meta.h
@@ -68,6 +68,10 @@ namespace Prismatic{
 			scanWindowXMax        = 0.99999;
 			scanWindowYMin        = 0.0;
 			scanWindowYMax        = 0.99999;
+			scanWindowXMin_r	  = 0.0; //realspace alternatives to setting scan window
+			scanWindowXMax_r	  = 0.0;
+			scanWindowYMin_r      = 0.0;
+			scanWindowYMax_r      = 0.0;
 			srand(time(0));
 			randomSeed            = rand() % 100000;
 			algorithm             = Algorithm::PRISM;
@@ -78,6 +82,8 @@ namespace Prismatic{
 			save3DOutput          = true;
 			save4DOutput          = false;
 			userSpecifiedCelldims = false;
+			realSpaceWindow_x	  = false;
+			realSpaceWindow_y	  = false;
 			integrationAngleMin   = 0;
 			integrationAngleMax   = detectorAngleStep;
 			transferMode          = StreamingMode::Auto;
@@ -115,6 +121,10 @@ namespace Prismatic{
 		T scanWindowXMax;
 		T scanWindowYMin;
 		T scanWindowYMax;
+		T scanWindowXMin_r;
+		T scanWindowXMax_r;
+		T scanWindowYMin_r;
+		T scanWindowYMax_r;
 		T randomSeed;
 		size_t numThreads; // number of CPU threads to use
 		size_t numGPUs; // number of GPUs to use
@@ -179,6 +189,10 @@ namespace Prismatic{
 		std::cout << "scanWindowXMax = " << scanWindowXMax<< std::endl;
 		std::cout << "scanWindowYMin = " << scanWindowYMin<< std::endl;
 		std::cout << "scanWindowYMax = " << scanWindowYMax<< std::endl;
+		std::cout << "scanWindowXMin_r = " << scanWindowXMin_r<< std::endl;
+		std::cout << "scanWindowXMax_r = " << scanWindowXMax_r<< std::endl;
+		std::cout << "scanWindowYMin_r = " << scanWindowYMin_r<< std::endl;
+		std::cout << "scanWindowYMax_r = " << scanWindowYMax_r<< std::endl;
 		std::cout << "integrationAngleMin = " << integrationAngleMin<< std::endl;
 		std::cout << "integrationAngleMax = " << integrationAngleMax<< std::endl;
 		std::cout << "randomSeed = " << randomSeed << std::endl;
@@ -264,6 +278,10 @@ namespace Prismatic{
 		if(scanWindowXMax != other.scanWindowXMax)return false;
 		if(scanWindowYMin != other.scanWindowYMin)return false;
 		if(scanWindowYMax != other.scanWindowYMax)return false;
+		if(scanWindowXMin_r != other.scanWindowXMin_r)return false;
+		if(scanWindowXMax_r != other.scanWindowXMax_r)return false;
+		if(scanWindowYMin_r != other.scanWindowYMin_r)return false;
+		if(scanWindowYMax_r != other.scanWindowYMax_r)return false;
 		if(randomSeed != other.randomSeed)return false;
 		if(includeThermalEffects != other.includeThermalEffects)return false;
 		if(includeOccupancy != other.includeOccupancy)return false;

--- a/include/meta.h
+++ b/include/meta.h
@@ -31,8 +31,9 @@ namespace Prismatic{
 		Metadata(){
 			interpolationFactorY  = 4;
 			interpolationFactorX  = 4;
-			filenameAtoms        = "/path/to/atoms.txt";
-			filenameOutput       = "output.mrc";
+			filenameAtoms         = "/path/to/atoms.txt";
+			filenameOutput        = "output.mrc";
+			outputFolder          = ""
 			realspacePixelSize[0] = 0.1;
 			realspacePixelSize[1] = 0.1;
 			potBound              = 2.0;
@@ -94,6 +95,7 @@ namespace Prismatic{
 		size_t interpolationFactorX; // PRISM f_x parameter
 		std::string filenameAtoms; // filename of txt file containing atoms (x,y,z,Z CSV format -- one atom per line)
 		std::string filenameOutput;// filename of output image
+		std::string outputFolder; // folder of output images
 		T realspacePixelSize[2]; // pixel size
 		T potBound; // bounding integration radius for potential calculation
 		size_t numFP; // number of frozen phonon configurations to compute
@@ -163,6 +165,7 @@ namespace Prismatic{
 
 		std::cout << "filenameAtoms = " <<  filenameAtoms     << std::endl;
 		std::cout << "filenameOutput = " << filenameOutput  << std::endl;
+		std::cout << "outputFolder = " << outputFolder  << std::endl;
 		std::cout << "numThreads = " << numThreads << std::endl;
 		std::cout << "realspacePixelSize[0] = " << realspacePixelSize[0]<< std::endl;
 		std::cout << "realspacePixelSize[1] = " << realspacePixelSize[1]<< std::endl;
@@ -266,6 +269,7 @@ namespace Prismatic{
 		if(interpolationFactorX != other.interpolationFactorX)return false;
 		if(filenameAtoms != other.filenameAtoms)return false;
 		if(filenameOutput != other.filenameOutput)return false;
+		if(outputFolder != other.outputFolder)return false;
 		if(realspacePixelSize[0] != realspacePixelSize[0])return false;
 		if(realspacePixelSize[1] != other.realspacePixelSize[1])return false;
 		if(potBound != other.potBound)return false;

--- a/include/meta.h
+++ b/include/meta.h
@@ -33,7 +33,7 @@ namespace Prismatic{
 			interpolationFactorX  = 4;
 			filenameAtoms         = "/path/to/atoms.txt";
 			filenameOutput        = "output.mrc";
-			outputFolder          = ""
+			outputFolder          = "";
 			realspacePixelSize[0] = 0.1;
 			realspacePixelSize[1] = 0.1;
 			potBound              = 2.0;

--- a/include/meta.h
+++ b/include/meta.h
@@ -81,6 +81,7 @@ namespace Prismatic{
 			save2DOutput          = false;
 			save3DOutput          = true;
 			save4DOutput          = false;
+			saveRealSpaceCoords	  = false;
 			userSpecifiedCelldims = false;
 			realSpaceWindow_x	  = false;
 			realSpaceWindow_y	  = false;
@@ -138,7 +139,10 @@ namespace Prismatic{
 		T integrationAngleMax;
 		bool save3DOutput;
 		bool save4DOutput;
+		bool saveRealSpaceCoords;
 		bool userSpecifiedCelldims;
+		bool realSpaceWindow_x;
+		bool realSpaceWindow_y;
 		StreamingMode transferMode;
 
 	};
@@ -227,6 +231,11 @@ namespace Prismatic{
 		} else {
 			std::cout << "save4DOutput = false" << std::endl;
 		}
+		if (saveRealSpaceCoords) {
+			std::cout << "saveRealSpaceCoords = true" << std::endl;
+		} else {
+			std::cout << "saveRealSpaceCoords = false" << std::endl;
+		}
 
 
 #ifdef PRISMATIC_ENABLE_GPU
@@ -289,7 +298,10 @@ namespace Prismatic{
 		if(save2DOutput != other.save2DOutput)return false;
 		if(save3DOutput != other.save3DOutput)return false;
 		if(save4DOutput != other.save4DOutput)return false;
+		if(saveRealSpaceCoords != other.saveRealSpaceCoords)return false;
 		if(userSpecifiedCelldims != other.userSpecifiedCelldims)return false;
+		if(realSpaceWindow_x != other.realSpaceWindow_x)return false;
+		if(realSpaceWindow_y != other.realSpaceWindow_y)return false;
 		return true;
 	}
 

--- a/include/meta.h
+++ b/include/meta.h
@@ -39,6 +39,7 @@ namespace Prismatic{
 			numFP                 = 1;
             fpNum                 = 1;
 			sliceThickness        = 2.0;
+			numSlices		      = 0; //to give a logic check, so that intermediate output only given when positive integer is given
 			cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
 			tileX                 = 1;
 			tileY                 = 1;
@@ -89,6 +90,7 @@ namespace Prismatic{
 		size_t numFP; // number of frozen phonon configurations to compute
 		size_t fpNum; // current frozen phonon number
 		T sliceThickness; // thickness of slice in Z
+		size_t numSlices; //number of slices to itereate through in multislice before giving an output
 		T probeStepX;
 		T probeStepY;
 		std::vector<T> cellDim; // this is z,y,x format
@@ -149,7 +151,8 @@ namespace Prismatic{
 		std::cout << "potBound = " << potBound << std::endl;
 		std::cout << "numFP = " << numFP << std::endl;
 		std::cout << "sliceThickness = " << sliceThickness<< std::endl;
-		std::cout << "E0 = " << E0 << std::endl;
+		std::cout << "numSlices = " << numSlices << std::endl;
+ 		std::cout << "E0 = " << E0 << std::endl;
 		std::cout << "alphaBeamMax = " << alphaBeamMax << std::endl;
 		std::cout << "numThreads = " << numThreads<< std::endl;
 		std::cout << "batchSizeTargetCPU = " << batchSizeTargetCPU<< std::endl;
@@ -235,6 +238,7 @@ namespace Prismatic{
 		if(potBound != other.potBound)return false;
 		if(numFP != other.numFP)return false;
 		if(sliceThickness != other.sliceThickness)return false;
+		if(numSlices != other.numSlices)return false;
 		if(cellDim[0] != other.cellDim[0])return false;
 		if(cellDim[1] != other.cellDim[1])return false;
 		if(cellDim[2] != other.cellDim[2])return false;

--- a/include/params.h
+++ b/include/params.h
@@ -94,6 +94,7 @@ namespace Prismatic{
         size_t Ndet;
         size_t numPlanes;
 		size_t numSlices;
+		size_t zStartPlane;
 	    size_t numberBeams;
 #ifdef PRISMATIC_ENABLE_GPU
 		cudaDeviceProp deviceProperties;
@@ -176,7 +177,10 @@ namespace Prismatic{
 		    pixelSize = _pixelSize;
 		    pixelSize[0] /= (T)imageSize[0];
 		    pixelSize[1] /= (T)imageSize[1];
+
 			numSlices = meta.numSlices;
+			zStartPlane = (size_t) std::floor(meta.zStart / meta.sliceThickness);
+
 
 		    // std::cout << " prism_pars.pixelSize[1] = " << pixelSize[1] << std::endl;
 		    // std::cout << " prism_pars.pixelSize[0] = " << pixelSize[0] << std::endl;

--- a/include/params.h
+++ b/include/params.h
@@ -93,6 +93,7 @@ namespace Prismatic{
 	    T alphaMax;
         size_t Ndet;
         size_t numPlanes;
+		size_t numSlices;
 	    size_t numberBeams;
 #ifdef PRISMATIC_ENABLE_GPU
 		cudaDeviceProp deviceProperties;
@@ -175,7 +176,7 @@ namespace Prismatic{
 		    pixelSize = _pixelSize;
 		    pixelSize[0] /= (T)imageSize[0];
 		    pixelSize[1] /= (T)imageSize[1];
-
+			numSlices = meta.numSlices;
 
 		    // std::cout << " prism_pars.pixelSize[1] = " << pixelSize[1] << std::endl;
 		    // std::cout << " prism_pars.pixelSize[0] = " << pixelSize[0] << std::endl;

--- a/include/params.h
+++ b/include/params.h
@@ -91,6 +91,10 @@ namespace Prismatic{
 	    T sigma;
 	    T qMax;
 	    T alphaMax;
+		T scanWindowXMin;
+		T scanWindowXMax;
+		T scanWindowYMin;
+		T scanWindowYMax;
         size_t Ndet;
         size_t numPlanes;
 		size_t numSlices;
@@ -149,6 +153,23 @@ namespace Prismatic{
 		    zTotal = tiledCellDim[0];
 		    xTiltShift = -zTotal * tan(meta.probeXtilt);
 		    yTiltShift = -zTotal * tan(meta.probeYtilt);
+
+			if(meta.realSpaceWindow_x){
+				scanWindowXMin = std::min(meta.scanWindowXMin_r, tiledCellDim[2]) / tiledCellDim[2] //default to max size if dimension exceeds tiled cell
+				scanWindowXMax = std::min(meta.scanWindowXMax_r, tiledCellDim[2]) / tiledCellDim[2]
+			}else{
+				scanWindowXMin = meta.scanWindowXMin
+				scanWindowXMax = meta.scanWindowXMax
+			}
+
+			if(meta.realSpaceWindow_y){
+				scanWindowYMin = std::min(meta.scanWindowYMin_r, tiledCellDim[1]) / tiledCellDim[1] //default to max size if dimension exceeds tiled cell
+				scanWindowYMax = std::min(meta.scanWindowYMax_r, tiledCellDim[1]) / tiledCellDim[1]
+			}else{
+				scanWindowYMin = meta.scanWindowYMin
+				scanWindowYMax = meta.scanWindowYMax
+			}
+
 			calculateLambda();
 //		    lambda = (T)(h / sqrt(2 * m * e * meta.E0) / sqrt(1 + e * meta.E0 / 2 / m / c / c) * 1e10);
 		    sigma = (T)((2 * pi / lambda / meta.E0) * (m * c * c + e * meta.E0) /

--- a/include/params.h
+++ b/include/params.h
@@ -46,7 +46,7 @@ namespace Prismatic{
 	    void calculateLambda();
 	    Metadata<T> meta;
 	    Array3D< std::complex<T>  > Scompact;
-	    Array3D<T> output;
+	    Array4D<T> output;
 		Array3D<T> pot;
 	    Array3D<std::complex<PRISMATIC_FLOAT_PRECISION> > transmission;
 

--- a/include/params.h
+++ b/include/params.h
@@ -155,19 +155,19 @@ namespace Prismatic{
 		    yTiltShift = -zTotal * tan(meta.probeYtilt);
 
 			if(meta.realSpaceWindow_x){
-				scanWindowXMin = std::min(meta.scanWindowXMin_r, tiledCellDim[2]) / tiledCellDim[2] //default to max size if dimension exceeds tiled cell
-				scanWindowXMax = std::min(meta.scanWindowXMax_r, tiledCellDim[2]) / tiledCellDim[2]
+				scanWindowXMin = std::min(meta.scanWindowXMin_r, tiledCellDim[2]) / tiledCellDim[2]; //default to max size if dimension exceeds tiled cell
+				scanWindowXMax = std::min(meta.scanWindowXMax_r, tiledCellDim[2]) / tiledCellDim[2];
 			}else{
-				scanWindowXMin = meta.scanWindowXMin
-				scanWindowXMax = meta.scanWindowXMax
+				scanWindowXMin = meta.scanWindowXMin;
+				scanWindowXMax = meta.scanWindowXMax;
 			}
 
 			if(meta.realSpaceWindow_y){
-				scanWindowYMin = std::min(meta.scanWindowYMin_r, tiledCellDim[1]) / tiledCellDim[1] //default to max size if dimension exceeds tiled cell
-				scanWindowYMax = std::min(meta.scanWindowYMax_r, tiledCellDim[1]) / tiledCellDim[1]
+				scanWindowYMin = std::min(meta.scanWindowYMin_r, tiledCellDim[1]) / tiledCellDim[1]; //default to max size if dimension exceeds tiled cell
+				scanWindowYMax = std::min(meta.scanWindowYMax_r, tiledCellDim[1]) / tiledCellDim[1];
 			}else{
-				scanWindowYMin = meta.scanWindowYMin
-				scanWindowYMax = meta.scanWindowYMax
+				scanWindowYMin = meta.scanWindowYMin;
+				scanWindowYMax = meta.scanWindowYMax;
 			}
 
 			calculateLambda();
@@ -200,7 +200,7 @@ namespace Prismatic{
 		    pixelSize[1] /= (T)imageSize[1];
 
 			numSlices = meta.numSlices;
-			zStartPlane = (size_t) std::floor(meta.zStart / meta.sliceThickness);
+			zStartPlane = (size_t) std::ceil(meta.zStart / meta.sliceThickness);
 
 
 		    // std::cout << " prism_pars.pixelSize[1] = " << pixelSize[1] << std::endl;

--- a/include/utility.cuh
+++ b/include/utility.cuh
@@ -168,6 +168,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
                                 const PRISMATIC_FLOAT_PRECISION *alphaInd_d,
                                 PRISMATIC_FLOAT_PRECISION *stack_ph,
                                 PRISMATIC_FLOAT_PRECISION *integratedOutput_ds,
+                                const size_t current_slice,
                                 const size_t ay,
                                 const size_t ax,
                                 const size_t& dimj,

--- a/include/utility.h
+++ b/include/utility.h
@@ -72,9 +72,10 @@ namespace Prismatic {
 	std::string generateFilename(const Parameters <T> &pars, const size_t currentSlice, const size_t ay, const size_t ax) {
 		std::string result = pars.meta.filenameOutput.substr(0, pars.meta.filenameOutput.find_last_of("."));
 		std::stringstream ss;
-		if(pars.meta.algorithm == Algorithm::PRISM){
+
+		if( (pars.meta.algorithm == Algorithm::PRISM) || (pars.meta.numSlices == 0) ) {
 		ss << "_X" << ax << "_Y" << ay << "_FP" << pars.meta.fpNum;
-		}else{
+		}else{	
 		ss << "_slice" << currentSlice << "_X" << ax << "_Y" << ay << "_FP" << pars.meta.fpNum;	
 		}
 		//result += "_X" + std::string(ax) + "_Y" + std::string(ay) + "_FP" + std::string(pars.meta.fpNum);

--- a/include/utility.h
+++ b/include/utility.h
@@ -70,7 +70,7 @@ namespace Prismatic {
 
 	template<class T>
 	std::string generateFilename(const Parameters <T> &pars, const size_t currentSlice, const size_t ay, const size_t ax) {
-		std::string result = pars.meta.filenameOutput.substr(0, pars.meta.filenameOutput.find_last_of("."));
+		std::string result = pars.meta.outputFolder + pars.meta.filenameOutput.substr(0, pars.meta.filenameOutput.find_last_of("."));
 		std::stringstream ss;
 
 		if( (pars.meta.algorithm == Algorithm::PRISM) || (pars.meta.numSlices == 0) ) {

--- a/include/utility.h
+++ b/include/utility.h
@@ -69,10 +69,14 @@ namespace Prismatic {
 	};
 
 	template<class T>
-	std::string generateFilename(const Parameters <T> &pars, const size_t ay, const size_t ax) {
+	std::string generateFilename(const Parameters <T> &pars, const size_t currentSlice, const size_t ay, const size_t ax) {
 		std::string result = pars.meta.filenameOutput.substr(0, pars.meta.filenameOutput.find_last_of("."));
 		std::stringstream ss;
+		if(pars.meta.algorithm == Algorithm::PRISM){
 		ss << "_X" << ax << "_Y" << ay << "_FP" << pars.meta.fpNum;
+		}else{
+		ss << "_slice" << currentSlice << "_X" << ax << "_Y" << ay << "_FP" << pars.meta.fpNum;	
+		}
 		//result += "_X" + std::string(ax) + "_Y" + std::string(ay) + "_FP" + std::string(pars.meta.fpNum);
 		result += ss.str() + pars.meta.filenameOutput.substr(pars.meta.filenameOutput.find_last_of("."));
 		return result;

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -50,10 +50,10 @@ namespace Prismatic{
 
 		if(pars.meta.saveRealSpaceCoords){
 			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
-			std::string x_name = "real_space_x.mrc"
-			std::string y_name = "real_space_x.mrc"
-			real_mesh.first.toMRC_f(x_name.c_str())
-			real_mesh.second.toMRC_f(y_name.c_str())
+			std::string x_name = "real_space_x.mrc";
+			std::string y_name = "real_space_y.mrc";
+			real_mesh.first.toMRC_f(x_name.c_str());
+			real_mesh.second.toMRC_f(y_name.c_str());
 		}
 		
 		pars.xp = xp;
@@ -188,6 +188,7 @@ namespace Prismatic{
 		if(pars.zStartPlane > 0)  numLayers += ((pars.zStartPlane) % pars.numSlices == 0) - (pars.zStartPlane / pars.numSlices) ;
 
 		size_t firstLayer = (pars.zStartPlane / pars.numSlices) + ((pars.zStartPlane) % pars.numSlices != 0);
+		if(pars.zStartPlane == 0) firstLayer = 1;
 
 		cout << "Number of layers: " << numLayers << endl;
 		cout << "First output depth is at " << firstLayer * pars.meta.sliceThickness * pars.numSlices << " angstroms with steps of " << pars.numSlices * pars.meta.sliceThickness << " angstroms" << endl;

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -189,7 +189,7 @@ namespace Prismatic{
 		auto psi_ptr = psi.begin();
 		for (auto& j:intOutput) j = pow(abs(*psi_ptr++),2);
 
-		Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, complex<PRISMATIC_FLOAT_PRECISION> >({{psi.get_dimj()/2, psi.get_dimi()/2}});
+		Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{psi.get_dimj()/2, psi.get_dimi()/2}});
 
 		{
 			long offset_x = psi.get_dimi() / 4;
@@ -203,7 +203,6 @@ namespace Prismatic{
 				}
 			}
 		}
-
 
 		//save 4D output if applicable
 		if (pars.meta.save4DOutput) {

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -174,7 +174,7 @@ namespace Prismatic{
 	}
 
 	void createStack(Parameters<PRISMATIC_FLOAT_PRECISION>& pars){
-		size_t numLayers = pars.numPlanes / pars.numSlices  + (pars.numPlanes % pars.numSlices != 0);
+		size_t numLayers = (pars.numPlanes - pars.zStartPlane) / pars.numSlices  + ((pars.numPlanes - pars.zStartPlane) % pars.numSlices != 0);
 
 		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{numLayers, pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}
@@ -400,7 +400,7 @@ namespace Prismatic{
 				}
 				cout << "Location 6 plane " << a2 << endl;
 
-				if ( (((a2+1) % pars.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
+				if  ( ( (((a2+1) % pars.numSlices) == 0) && ((a2+1) >= pars.zStartPlane) ) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU_integrate_batch(pars, psi_stack, pars.alphaInd, Nstart, Nstop, currentSlice);
 					currentSlice++;
 				}
@@ -450,7 +450,7 @@ namespace Prismatic{
 				for (auto& p:psi)p *= (*p_ptr++); // propagate
 				cout << "Location 5 plane " << a2 << endl;
 				
-				if ( (((a2+1) % pars.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
+				if ( ( (((a2+1) % pars.numSlices) == 0) && ((a2+1) >= pars.zStartPlane) ) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU(pars, psi, pars.alphaInd, currentSlice, ay, ax);
 					currentSlice++;
 				}

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -50,8 +50,8 @@ namespace Prismatic{
 
 		if(pars.meta.saveRealSpaceCoords){
 			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
-			std::string x_name = "real_space_x.mrc";
-			std::string y_name = "real_space_y.mrc";
+			std::string x_name = pars.meta.outputFolder + "real_space_x.mrc";
+			std::string y_name = pars.meta.outputFolder + "real_space_y.mrc";
 			real_mesh.first.toMRC_f(x_name.c_str());
 			real_mesh.second.toMRC_f(y_name.c_str());
 		}

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -35,11 +35,11 @@ namespace Prismatic{
 
 		// setup coordinates and build propagators
 		Array1D<PRISMATIC_FLOAT_PRECISION> xR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		xR[0] = pars.meta.scanWindowXMin * pars.tiledCellDim[2];
-		xR[1] = pars.meta.scanWindowXMax * pars.tiledCellDim[2];
+		xR[0] = pars.scanWindowXMin * pars.tiledCellDim[2];
+		xR[1] = pars.scanWindowXMax * pars.tiledCellDim[2];
 		Array1D<PRISMATIC_FLOAT_PRECISION> yR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		yR[0] = pars.meta.scanWindowYMin * pars.tiledCellDim[1];
-		yR[1] = pars.meta.scanWindowYMax * pars.tiledCellDim[1];
+		yR[0] = pars.scanWindowYMin * pars.tiledCellDim[1];
+		yR[1] = pars.scanWindowYMax * pars.tiledCellDim[1];
 
 		vector<PRISMATIC_FLOAT_PRECISION> xp_d = vecFromRange(xR[0], pars.meta.probeStepX, xR[1]);
 		vector<PRISMATIC_FLOAT_PRECISION> yp_d = vecFromRange(yR[0], pars.meta.probeStepY, yR[1]);

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -189,10 +189,26 @@ namespace Prismatic{
 		auto psi_ptr = psi.begin();
 		for (auto& j:intOutput) j = pow(abs(*psi_ptr++),2);
 
+		Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, complex<PRISMATIC_FLOAT_PRECISION> >({{psi.get_dimj()/2, psi.get_dimi()/2}});
+
+		{
+			long offset_x = psi.get_dimi() / 4;
+			long offset_y = psi.get_dimj() / 4;
+			long ndimy = (long) psi.get_dimj();
+			long ndimx = (long) psi.get_dimi();
+			for (long y = 0; y < psi.get_dimj() / 2; ++y) {
+				for (long x = 0; x < psi.get_dimi() / 2; ++x) {
+					intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
+					                            ((x - offset_x) % ndimx + ndimx) % ndimx);
+				}
+			}
+		}
+
+
 		//save 4D output if applicable
 		if (pars.meta.save4DOutput) {
 			std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
-			intOutput.toMRC_f(section4DFilename.c_str());
+			intOutput_small.toMRC_f(section4DFilename.c_str());
 		}
 
 		//update stack -- ax,ay are unique per thread so this write is thread-safe without a lock
@@ -219,10 +235,26 @@ namespace Prismatic{
 			auto psi_ptr = &psi_stack[probe_idx*pars.psiProbeInit.size()];
 			for (auto &j:intOutput) j = pow(abs(*psi_ptr++), 2);
 
+			Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{pars.psiProbeInit.get_dimj()/2, pars.psiProbeInit.get_dimi()/2}});
+
+			{
+				long offset_x = pars.psiProbeInit.get_dimi() / 4;
+				long offset_y = pars.psiProbeInit.get_dimj() / 4;
+				long ndimy = (long) pars.psiProbeInit.get_dimj();
+				long ndimx = (long) pars.psiProbeInit.get_dimi();
+
+				for (long y = 0; y < pars.psiProbeInit.get_dimj() / 2; ++y) {
+					for (long x = 0; x < pars.psiProbeInit.get_dimi() / 2; ++x) {
+						intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
+													((x - offset_x) % ndimx + ndimx) % ndimx);
+					}
+				}
+			}
+
 			//save 4D output if applicable
 			if (pars.meta.save4DOutput) {
 				std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
-				intOutput.toMRC_f(section4DFilename.c_str());
+				intOutput_small.toMRC_f(section4DFilename.c_str());
 			}
 
 			//update stack -- ax,ay are unique per thread so this write is thread-safe without a lock

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -41,11 +41,21 @@ namespace Prismatic{
 		yR[0] = pars.scanWindowYMin * pars.tiledCellDim[1];
 		yR[1] = pars.scanWindowYMax * pars.tiledCellDim[1];
 
+
 		vector<PRISMATIC_FLOAT_PRECISION> xp_d = vecFromRange(xR[0], pars.meta.probeStepX, xR[1]);
 		vector<PRISMATIC_FLOAT_PRECISION> yp_d = vecFromRange(yR[0], pars.meta.probeStepY, yR[1]);
-
+		
 		Array1D<PRISMATIC_FLOAT_PRECISION> xp(xp_d, {{xp_d.size()}});
 		Array1D<PRISMATIC_FLOAT_PRECISION> yp(yp_d, {{yp_d.size()}});
+
+		if(pars.meta.saveRealSpaceCoords){
+			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
+			std::string x_name = "real_space_x.mrc"
+			std::string y_name = "real_space_x.mrc"
+			real_mesh.first.toMRC_f(x_name.c_str())
+			real_mesh.second.toMRC_f(y_name.c_str())
+		}
+		
 		pars.xp = xp;
 		pars.yp = yp;
 		pars.imageSize[0] = pars.pot.get_dimj();

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -174,7 +174,11 @@ namespace Prismatic{
 	}
 
 	void createStack(Parameters<PRISMATIC_FLOAT_PRECISION>& pars){
-		size_t numLayers = (pars.numPlanes - pars.zStartPlane) / pars.numSlices  + ((pars.numPlanes - pars.zStartPlane) % pars.numSlices != 0);
+		size_t numLayers = (pars.numPlanes / pars.numSlices) - (pars.zStartPlane / pars.numSlices)  + ((pars.numPlanes) % pars.numSlices != 0) + ((pars.zStartPlane) % pars.numSlices == 0);
+		size_t firstLayer = (pars.zStartPlane / pars.numSlices) + ((pars.zStartPlane) % pars.numSlices != 0);
+
+		cout << "Number of layers: " << numLayers << endl;
+		cout << "First output depth is at " << firstLayer * pars.meta.sliceThickness * pars.numSlices << " angstroms with steps of " << pars.numSlices * pars.meta.sliceThickness << endl;
 
 		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{numLayers, pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}
@@ -398,7 +402,6 @@ namespace Prismatic{
 						*psi_ptr++ *= (*p_ptr++);// propagate
 					}
 				}
-				cout << "Location 6 plane " << a2 << endl;
 
 				if  ( ( (((a2+1) % pars.numSlices) == 0) && ((a2+1) >= pars.zStartPlane) ) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU_integrate_batch(pars, psi_stack, pars.alphaInd, Nstart, Nstop, currentSlice);
@@ -448,7 +451,6 @@ namespace Prismatic{
 				PRISMATIC_FFTW_EXECUTE(plan_forward);
 				auto p_ptr = scaled_prop.begin();
 				for (auto& p:psi)p *= (*p_ptr++); // propagate
-				cout << "Location 5 plane " << a2 << endl;
 				
 				if ( ( (((a2+1) % pars.numSlices) == 0) && ((a2+1) >= pars.zStartPlane) ) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU(pars, psi, pars.alphaInd, currentSlice, ay, ax);

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -174,7 +174,7 @@ namespace Prismatic{
 	}
 
 	void createStack(Parameters<PRISMATIC_FLOAT_PRECISION>& pars){
-		size_t numLayers = pars.numPlanes / pars.meta.numSlices  + (pars.numPlanes % pars.meta.numSlices != 0);
+		size_t numLayers = pars.numPlanes / pars.numSlices  + (pars.numPlanes % pars.numSlices != 0);
 
 		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{numLayers, pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}
@@ -400,7 +400,7 @@ namespace Prismatic{
 				}
 				cout << "Location 6 plane " << a2 << endl;
 
-				if ( (((a2+1) % pars.meta.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
+				if ( (((a2+1) % pars.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU_integrate_batch(pars, psi_stack, pars.alphaInd, Nstart, Nstop, currentSlice);
 					currentSlice++;
 				}
@@ -450,7 +450,7 @@ namespace Prismatic{
 				for (auto& p:psi)p *= (*p_ptr++); // propagate
 				cout << "Location 5 plane " << a2 << endl;
 				
-				if ( (((a2+1) % pars.meta.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
+				if ( (((a2+1) % pars.numSlices) == 0) || ((a2+1) == pars.numPlanes) ){
 					formatOutput_CPU(pars, psi, pars.alphaInd, currentSlice, ay, ax);
 					currentSlice++;
 				}

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -174,11 +174,13 @@ namespace Prismatic{
 	}
 
 	void createStack(Parameters<PRISMATIC_FLOAT_PRECISION>& pars){
-		size_t numLayers = (pars.numPlanes / pars.numSlices) - (pars.zStartPlane / pars.numSlices)  + ((pars.numPlanes) % pars.numSlices != 0) + ((pars.zStartPlane) % pars.numSlices == 0);
+		size_t numLayers = (pars.numPlanes / pars.numSlices) + ((pars.numPlanes) % pars.numSlices != 0);
+		if(pars.zStartPlane > 0)  numLayers += ((pars.zStartPlane) % pars.numSlices == 0) - (pars.zStartPlane / pars.numSlices) ;
+
 		size_t firstLayer = (pars.zStartPlane / pars.numSlices) + ((pars.zStartPlane) % pars.numSlices != 0);
 
 		cout << "Number of layers: " << numLayers << endl;
-		cout << "First output depth is at " << firstLayer * pars.meta.sliceThickness * pars.numSlices << " angstroms with steps of " << pars.numSlices * pars.meta.sliceThickness << endl;
+		cout << "First output depth is at " << firstLayer * pars.meta.sliceThickness * pars.numSlices << " angstroms with steps of " << pars.numSlices * pars.meta.sliceThickness << " angstroms" << endl;
 
 		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{numLayers, pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}

--- a/src/Multislice_calcOutput.cu
+++ b/src/Multislice_calcOutput.cu
@@ -644,7 +644,6 @@ namespace Prismatic{
 				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
 				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-				cout << "Location 1 plane " << planeNum << '\n';
 
 				if ( ( (((planeNum+1) % pars.numSlices) == 0 ) && ((planeNum+1) >= pars.zStartPlane)) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
@@ -686,7 +685,6 @@ namespace Prismatic{
                 (psi_ds + (batch_idx * psi_size), PsiProbeInit_d, qya_d, qxa_d, psi_size, yp, xp);
 		}
 		size_t currentSlice = 0;
-		cout << "Output array size: " << pars.output.size() << '\n';
 
 			for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
 				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
@@ -701,10 +699,9 @@ namespace Prismatic{
 					divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
 							(psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				}
-				cout << "Location 4 plane " << planeNum << '\n';
 				
 				if ( ((((planeNum+1) % pars.numSlices) == 0) && ((planeNum+1) >= pars.zStartPlane)) || ((planeNum+1) == pars.numPlanes) ){
-					cout << "Current Slice: " << currentSlice << '\n';
+
 					abs_squared << < ( psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
 						const size_t ay = (Nstart + batch_idx) / pars.xp.size();
@@ -752,7 +749,6 @@ namespace Prismatic{
 				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
 				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-				cout << "Location 2 plane " << planeNum << '\n';
 
 				if ( ( (((planeNum+1) % pars.numSlices) == 0) && ((planeNum+1) >= pars.zStartPlane) ) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
@@ -813,11 +809,11 @@ namespace Prismatic{
 					divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
 																	(psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				}
-				cout << "Location 3 plane " << planeNum << '\n';
+
 
 				if ( ( ((planeNum+1) % pars.numSlices) == 0 && ((planeNum+1) >= pars.zStartPlane) ) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared << < (psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
-		
+
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
 						const size_t ay = (Nstart + batch_idx) / pars.xp.size();
 						const size_t ax = (Nstart + batch_idx) % pars.xp.size();

--- a/src/Multislice_calcOutput.cu
+++ b/src/Multislice_calcOutput.cu
@@ -646,7 +646,7 @@ namespace Prismatic{
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				cout << "Location 1 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( ( (((planeNum+1) % pars.numSlices) == 0 ) && ((planeNum+1) >= pars.zStartPlane)) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
 					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds, currentSlice, ay, ax, dimj, dimi, stream);
 					currentSlice++;
@@ -703,7 +703,7 @@ namespace Prismatic{
 				}
 				cout << "Location 4 plane " << planeNum << '\n';
 				
-				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( ((((planeNum+1) % pars.numSlices) == 0) && ((planeNum+1) >= pars.zStartPlane)) || ((planeNum+1) == pars.numPlanes) ){
 					cout << "Current Slice: " << currentSlice << '\n';
 					abs_squared << < ( psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
@@ -754,7 +754,7 @@ namespace Prismatic{
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				cout << "Location 2 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( ( (((planeNum+1) % pars.numSlices) == 0) && ((planeNum+1) >= pars.zStartPlane) ) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
 		
 					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds,currentSlice, ay, ax, dimj, dimi,stream);
@@ -815,7 +815,7 @@ namespace Prismatic{
 				}
 				cout << "Location 3 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( ( ((planeNum+1) % pars.numSlices) == 0 && ((planeNum+1) >= pars.zStartPlane) ) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared << < (psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
 		
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {

--- a/src/Multislice_calcOutput.cu
+++ b/src/Multislice_calcOutput.cu
@@ -646,7 +646,7 @@ namespace Prismatic{
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				cout << "Location 1 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
 					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds, currentSlice, ay, ax, dimj, dimi, stream);
 					currentSlice++;
@@ -703,7 +703,7 @@ namespace Prismatic{
 				}
 				cout << "Location 4 plane " << planeNum << '\n';
 				
-				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
 					cout << "Current Slice: " << currentSlice << '\n';
 					abs_squared << < ( psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
@@ -754,7 +754,7 @@ namespace Prismatic{
 				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
 				cout << "Location 2 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
 		
 					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds,currentSlice, ay, ax, dimj, dimi,stream);
@@ -815,7 +815,7 @@ namespace Prismatic{
 				}
 				cout << "Location 3 plane " << planeNum << '\n';
 
-				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+				if ( (((planeNum+1) % pars.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
 					abs_squared << < (psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
 		
 					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {

--- a/src/Multislice_calcOutput.cu
+++ b/src/Multislice_calcOutput.cu
@@ -634,16 +634,26 @@ namespace Prismatic{
 		PRISMATIC_FLOAT_PRECISION yp = pars.yp[ay];
 		PRISMATIC_FLOAT_PRECISION xp = pars.xp[ax];
 		const size_t psi_size = dimj*dimi;
+		size_t currentSlice = 0;
+
 		initializePsi<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PsiProbeInit_d, qya_d, qxa_d, psi_size, yp, xp);
-		for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
-			multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, &trans_d[planeNum*psi_size], psi_size);
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
-			multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
-			divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-		}
-		abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
-		formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds, ay, ax, dimj, dimi, stream);
+		
+			for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
+				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, &trans_d[planeNum*psi_size], psi_size);
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
+				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
+				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
+				cout << "Location 1 plane " << planeNum << '\n';
+
+				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
+					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds, currentSlice, ay, ax, dimj, dimi, stream);
+					currentSlice++;
+				}
+			}
+
+		
 }
 
 	__host__ void getMultisliceProbe_GPU_singlexfer_batch(Parameters<PRISMATIC_FLOAT_PRECISION>& pars,
@@ -675,27 +685,38 @@ namespace Prismatic{
 			initializePsi << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
                 (psi_ds + (batch_idx * psi_size), PsiProbeInit_d, qya_d, qxa_d, psi_size, yp, xp);
 		}
-		for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
-			for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-				multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-						(psi_ds + (batch_idx * psi_size), &trans_d[planeNum * psi_size], psi_size);
+		size_t currentSlice = 0;
+		cout << "Output array size: " << pars.output.size() << '\n';
+
+			for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
+				for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+					multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+							(psi_ds + (batch_idx * psi_size), &trans_d[planeNum * psi_size], psi_size);
+				}
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
+				for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+					multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+							(psi_ds + (batch_idx * psi_size), prop_d, psi_size);
+					divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+							(psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
+				}
+				cout << "Location 4 plane " << planeNum << '\n';
+				
+				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+					cout << "Current Slice: " << currentSlice << '\n';
+					abs_squared << < ( psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
+					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+						const size_t ay = (Nstart + batch_idx) / pars.xp.size();
+						const size_t ax = (Nstart + batch_idx) % pars.xp.size();
+						formatOutput_GPU_integrate(pars, psiIntensity_ds + (batch_idx * psi_size),
+												alphaInd_d, output_ph, integratedOutput_ds, currentSlice, ay, ax, dimj, dimi, stream);
+					}
+
+					currentSlice++;
+				}
 			}
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
-			for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-				multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-						(psi_ds + (batch_idx * psi_size), prop_d, psi_size);
-				divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-						(psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-			}
-		}
-		abs_squared << < ( psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
-		for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-			const size_t ay = (Nstart + batch_idx) / pars.xp.size();
-			const size_t ax = (Nstart + batch_idx) % pars.xp.size();
-			formatOutput_GPU_integrate(pars, psiIntensity_ds + (batch_idx * psi_size),
-			                           alphaInd_d, output_ph, integratedOutput_ds, ay, ax, dimj, dimi, stream);
-		}
+
 	}
 
 	__host__ void getMultisliceProbe_GPU_streaming(Parameters<PRISMATIC_FLOAT_PRECISION>& pars,
@@ -720,19 +741,27 @@ namespace Prismatic{
 		PRISMATIC_FLOAT_PRECISION yp = pars.yp[ay];
 		PRISMATIC_FLOAT_PRECISION xp = pars.xp[ax];
 		const size_t psi_size = dimj*dimi;
+		size_t currentSlice = 0;
 		initializePsi<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PsiProbeInit_d, qya_d, qxa_d, dimj*dimi, yp, xp);
 
+											
+			for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
+				cudaErrchk(cudaMemcpyAsync(trans_d, &trans_ph[planeNum*psi_size], psi_size * sizeof(PRISMATIC_CUDA_COMPLEX_FLOAT), cudaMemcpyHostToDevice, stream));
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
+				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, trans_d, psi_size);
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
+				multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
+				divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
+				cout << "Location 2 plane " << planeNum << '\n';
 
-		for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
-			cudaErrchk(cudaMemcpyAsync(trans_d, &trans_ph[planeNum*psi_size], psi_size * sizeof(PRISMATIC_CUDA_COMPLEX_FLOAT), cudaMemcpyHostToDevice, stream));
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
-			multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, trans_d, psi_size);
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
-			multiply_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, prop_d, psi_size);
-			divide_inplace<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psi_ds, PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-		}
-		abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
-		formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds, ay, ax, dimj, dimi,stream);
+				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+					abs_squared<<<(psi_size - 1) / BLOCK_SIZE1D + 1,BLOCK_SIZE1D, 0, stream>>>(psiIntensity_ds, psi_ds, psi_size);
+		
+					formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph, integratedOutput_ds,currentSlice, ay, ax, dimj, dimi,stream);
+					currentSlice++;
+				}
+			}
+		
 	}
 
 
@@ -766,29 +795,42 @@ namespace Prismatic{
 			                                                (psi_ds + (batch_idx * psi_size), PsiProbeInit_d, qya_d, qxa_d, psi_size, yp, xp);
 		}
 
-		for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
+		size_t currentSlice = 0;
 
-			cudaErrchk(cudaMemcpyAsync(trans_d, &trans_ph[planeNum*psi_size], psi_size * sizeof(PRISMATIC_CUDA_COMPLEX_FLOAT), cudaMemcpyHostToDevice, stream));
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
-			for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-				multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-				                                                   (psi_ds + (batch_idx * psi_size), trans_d, psi_size);
+
+			for (auto planeNum = 0; planeNum < pars.numPlanes; ++planeNum) {
+
+				cudaErrchk(cudaMemcpyAsync(trans_d, &trans_ph[planeNum*psi_size], psi_size * sizeof(PRISMATIC_CUDA_COMPLEX_FLOAT), cudaMemcpyHostToDevice, stream));
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_INVERSE));
+				for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+					multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+																	(psi_ds + (batch_idx * psi_size), trans_d, psi_size);
+				}
+				cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
+				for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+					multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+																	(psi_ds + (batch_idx * psi_size), prop_d, psi_size);
+					divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
+																	(psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
+				}
+				cout << "Location 3 plane " << planeNum << '\n';
+
+				if ( (((planeNum+1) % pars.meta.numSlices) == 0) || ((planeNum+1) == pars.numPlanes) ){
+					abs_squared << < (psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
+		
+					for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
+						const size_t ay = (Nstart + batch_idx) / pars.xp.size();
+						const size_t ax = (Nstart + batch_idx) % pars.xp.size();
+						formatOutput_GPU_integrate(pars, psiIntensity_ds + (batch_idx * psi_size),
+												alphaInd_d, output_ph, integratedOutput_ds, currentSlice, ay, ax, dimj, dimi, stream);
+					}
+					currentSlice++;
+				}
+			
 			}
-			cufftErrchk(PRISMATIC_CUFFT_EXECUTE(plan, &psi_ds[0], &psi_ds[0], CUFFT_FORWARD));
-			for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-				multiply_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-				                                                   (psi_ds + (batch_idx * psi_size), prop_d, psi_size);
-				divide_inplace << < (psi_size - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> >
-				                                                 (psi_ds + (batch_idx * psi_size), PRISMATIC_MAKE_CU_COMPLEX(psi_size, 0), psi_size);
-			}
-		}
-		abs_squared << < (psi_size*(Nstop-Nstart) - 1) / BLOCK_SIZE1D + 1, BLOCK_SIZE1D, 0, stream >> > (psiIntensity_ds, psi_ds, psi_size*(Nstop-Nstart));
-		for (auto batch_idx = 0; batch_idx < (Nstop-Nstart); ++batch_idx) {
-			const size_t ay = (Nstart + batch_idx) / pars.xp.size();
-			const size_t ax = (Nstart + batch_idx) % pars.xp.size();
-			formatOutput_GPU_integrate(pars, psiIntensity_ds + (batch_idx * psi_size),
-			                           alphaInd_d, output_ph, integratedOutput_ds, ay, ax, dimj, dimi, stream);
-		}
+
+
+		
 	}
     __host__ void buildMultisliceOutput_GPU_singlexfer(Parameters <PRISMATIC_FLOAT_PRECISION> &pars){
 		using namespace std;

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -95,7 +95,7 @@ namespace Prismatic{
 							}
 						}
 					}
-					if (prismatic_pars.meta.numSlices != 0 ){
+					if (prismatic_pars.meta.numSlices != 0){
 						image_filename = (std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_")) + prismatic_pars.meta.filenameOutput;
 					}
 					prism_image.toMRC_f(image_filename.c_str());

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -41,7 +41,7 @@ namespace Prismatic{
 		// calculate remaining frozen phonon configurations
 		if (prismatic_pars.meta.numFP > 1) {
 			// run the rest of the frozen phonons
-			Array3D<PRISMATIC_FLOAT_PRECISION> net_output(prismatic_pars.output);
+			Array4D<PRISMATIC_FLOAT_PRECISION> net_output(prismatic_pars.output);
 			for (auto fp_num = 1; fp_num < prismatic_pars.meta.numFP; ++fp_num){
 				meta.randomSeed = rand() % 100000;
 				++meta.fpNum;
@@ -57,24 +57,74 @@ namespace Prismatic{
 			prismatic_pars.output = net_output;
 		}
 
-		if (prismatic_pars.meta.save3DOutput)prismatic_pars.output.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
+		if (prismatic_pars.meta.save3DOutput){
+			if (prismatic_pars.meta.numSlices == 0){
+				//create dummy array to pass to
+				Array3D<PRISMATIC_FLOAT_PRECISION> output_image = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.output.get_dimk(),prismatic_pars.output.get_dimj(),prismatic_pars.output.get_dimi()}});
+				
+				for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y){
+					for (auto x = 0; x < prismatic_pars.output.get_dimj();++x){
+						for (auto b = 0; b < prismatic_pars.output.get_dimi(); ++b){
+							output_image.at(y,x,b) = prismatic_pars.output.at(0,y,x,b);
+						}
+					}
+				}
+
+				output_image.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
+			}else{
+				std::string slice_filename;
+				Array3D<PRISMATIC_FLOAT_PRECISION> slice_image;
+				slice_image = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.output.get_dimk(),prismatic_pars.output.get_dimj(),prismatic_pars.output.get_dimi()}});
+
+				for (auto j = 0; j < prismatic_pars.output.get_diml(); j++){
+
+					for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y){
+						for (auto x = 0; x < prismatic_pars.output.get_dimj();++x){
+							for (auto b = 0; b < prismatic_pars.output.get_dimi(); ++b){
+								slice_image.at(y,x,b) = prismatic_pars.output.at(j,y,x,b);
+							}
+						}
+					}
+
+					slice_filename = std::string("slice")+std::to_string(j)+std::string("_")+prismatic_pars.meta.filenameOutput;
+					slice_image.toMRC_f(slice_filename.c_str());
+				}
+			}
+		}
 
 		if (prismatic_pars.meta.save2DOutput) {
 			size_t lower = std::max((size_t)0, (size_t)(prismatic_pars.meta.integrationAngleMin / prismatic_pars.meta.detectorAngleStep));
 			size_t upper = std::min(prismatic_pars.detectorAngles.size(), (size_t) (prismatic_pars.meta.integrationAngleMax / prismatic_pars.meta.detectorAngleStep));
 			Array2D<PRISMATIC_FLOAT_PRECISION> prism_image;
+			std::string image_filename;
 			prism_image = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
 					{{prismatic_pars.output.get_dimk(), prismatic_pars.output.get_dimj()}});
-			for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
-				for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
-					for (auto b = lower; b < upper; ++b) {
-						prism_image.at(y, x) += prismatic_pars.output.at(y, x, b);
+
+			if (prismatic_pars.meta.numSlices == 0){		
+				for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
+					for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
+						for (auto b = lower; b < upper; ++b) {
+							prism_image.at(y, x) += prismatic_pars.output.at(0, y, x, b);
+						}
 					}
 				}
+				image_filename = std::string("multislice_2Doutput_") + prismatic_pars.meta.filenameOutput;
+				prism_image.toMRC_f(image_filename.c_str());
+			}else{
+				for (auto j = 0; j < prismatic_pars.output.get_diml(); j++){
+					for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
+						for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
+							for (auto b = lower; b < upper; ++b) {
+								prism_image.at(y, x) += prismatic_pars.output.at(j, y, x, b);
+							}
+						}
+					}
+					image_filename = std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_") + prismatic_pars.meta.filenameOutput;
+					prism_image.toMRC_f(image_filename.c_str());
+				}
 			}
-			std::string image_filename = std::string("multislice_2Doutput_") + prismatic_pars.meta.filenameOutput;
-			prism_image.toMRC_f(image_filename.c_str());
 		}
+
 #ifdef PRISMATIC_ENABLE_GPU
 		cout << "peak GPU memory usage = " << prismatic_pars.maxGPUMem << '\n';
 #endif //PRISMATIC_ENABLE_GPU

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -72,7 +72,7 @@ namespace Prismatic{
 							}
 						}
 					}
-					if ( prismatic_pars.meta.numSlices != 0) slice_filename = std::string("slice")+std::to_string(j)+std::string("_") + prismatic_pars.meta.filenameOutput;
+					if ( prismatic_pars.meta.numSlices != 0) slice_filename = prismatic_pars.meta.outputFolder + std::string("slice")+std::to_string(j)+std::string("_") + prismatic_pars.meta.filenameOutput;
 					slice_image.toMRC_f(slice_filename.c_str());
 				}
 		}
@@ -96,7 +96,7 @@ namespace Prismatic{
 						}
 					}
 					if (prismatic_pars.meta.numSlices != 0){
-						image_filename = (std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_")) + prismatic_pars.meta.filenameOutput;
+						image_filename = prismatic_pars.meta.outputFolder +  (std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_")) + prismatic_pars.meta.filenameOutput;
 					}
 					prism_image.toMRC_f(image_filename.c_str());
 					

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -58,21 +58,8 @@ namespace Prismatic{
 		}
 
 		if (prismatic_pars.meta.save3DOutput){
-			if (prismatic_pars.meta.numSlices == 0){
 				//create dummy array to pass to
-				Array3D<PRISMATIC_FLOAT_PRECISION> output_image = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.output.get_dimk(),prismatic_pars.output.get_dimj(),prismatic_pars.output.get_dimi()}});
-				
-				for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y){
-					for (auto x = 0; x < prismatic_pars.output.get_dimj();++x){
-						for (auto b = 0; b < prismatic_pars.output.get_dimi(); ++b){
-							output_image.at(y,x,b) = prismatic_pars.output.at(0,y,x,b);
-						}
-					}
-				}
-
-				output_image.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
-			}else{
-				std::string slice_filename;
+				std::string slice_filename = prismatic_pars.meta.filenameOutput;
 				Array3D<PRISMATIC_FLOAT_PRECISION> slice_image;
 				slice_image = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.output.get_dimk(),prismatic_pars.output.get_dimj(),prismatic_pars.output.get_dimi()}});
 
@@ -85,33 +72,22 @@ namespace Prismatic{
 							}
 						}
 					}
-
-					slice_filename = std::string("slice")+std::to_string(j)+std::string("_")+prismatic_pars.meta.filenameOutput;
+					if ( prismatic_pars.meta.numSlices != 0) slice_filename = std::string("slice")+std::to_string(j)+std::string("_") + prismatic_pars.meta.filenameOutput;
 					slice_image.toMRC_f(slice_filename.c_str());
 				}
-			}
 		}
 
 		if (prismatic_pars.meta.save2DOutput) {
 			size_t lower = std::max((size_t)0, (size_t)(prismatic_pars.meta.integrationAngleMin / prismatic_pars.meta.detectorAngleStep));
 			size_t upper = std::min(prismatic_pars.detectorAngles.size(), (size_t) (prismatic_pars.meta.integrationAngleMax / prismatic_pars.meta.detectorAngleStep));
 			Array2D<PRISMATIC_FLOAT_PRECISION> prism_image;
-			std::string image_filename;
-			prism_image = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
-					{{prismatic_pars.output.get_dimk(), prismatic_pars.output.get_dimj()}});
+			std::string image_filename = std::string("multislice_2Doutput")+prismatic_pars.meta.filenameOutput;
 
-			if (prismatic_pars.meta.numSlices == 0){		
-				for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
-					for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
-						for (auto b = lower; b < upper; ++b) {
-							prism_image.at(y, x) += prismatic_pars.output.at(0, y, x, b);
-						}
-					}
-				}
-				image_filename = std::string("multislice_2Doutput_") + prismatic_pars.meta.filenameOutput;
-				prism_image.toMRC_f(image_filename.c_str());
-			}else{
 				for (auto j = 0; j < prismatic_pars.output.get_diml(); j++){
+					//need to initiliaze output image at each slice to prevent overflow of value
+					prism_image = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
+						{{prismatic_pars.output.get_dimk(), prismatic_pars.output.get_dimj()}});
+
 					for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
 						for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
 							for (auto b = lower; b < upper; ++b) {
@@ -119,10 +95,12 @@ namespace Prismatic{
 							}
 						}
 					}
-					image_filename = std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_") + prismatic_pars.meta.filenameOutput;
+					if (prismatic_pars.meta.numSlices != 0 ){
+						image_filename = (std::string("multislice_2Doutput_slice") + std::to_string(j) + std::string("_")) + prismatic_pars.meta.filenameOutput;
+					}
 					prism_image.toMRC_f(image_filename.c_str());
+					
 				}
-			}
 		}
 
 #ifdef PRISMATIC_ENABLE_GPU

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -94,7 +94,7 @@ namespace Prismatic {
 
 		//check if intermediate output was specified, if so, create index of output slices
 		if(pars.meta.numSlices == 0){
-			pars.meta.numSlices = pars.numPlanes;
+			pars.numSlices = pars.numPlanes;
 		}
 
 #ifdef PRISMATIC_BUILDING_GUI

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -211,5 +211,11 @@ namespace Prismatic {
 
 		// populate the slices with the projected potentials
 		generateProjectedPotentials(pars, potentialLookup, unique_species, xvec, yvec);
+
+		if(pars.meta.savePotentialSlices){
+			std::string file_name = "potential_slices.mrc"
+			pars.pot.toMRC_f(file_name.c_str())
+		}
+
 	}
 }

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -213,8 +213,8 @@ namespace Prismatic {
 		generateProjectedPotentials(pars, potentialLookup, unique_species, xvec, yvec);
 
 		if(pars.meta.savePotentialSlices){
-			std::string file_name = "potential_slices.mrc"
-			pars.pot.toMRC_f(file_name.c_str())
+			std::string file_name = "potential_slices.mrc";
+			pars.pot.toMRC_f(file_name.c_str());
 		}
 
 	}

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -213,7 +213,7 @@ namespace Prismatic {
 		generateProjectedPotentials(pars, potentialLookup, unique_species, xvec, yvec);
 
 		if(pars.meta.savePotentialSlices){
-			std::string file_name = "potential_slices.mrc";
+			std::string file_name = pars.meta.outputFolder + "potential_slices.mrc";
 			pars.pot.toMRC_f(file_name.c_str());
 		}
 

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -91,6 +91,12 @@ namespace Prismatic {
 		});
 		max_z = std::max_element(zPlane.begin(), zPlane.end());
 		pars.numPlanes = *max_z + 1;
+
+		//check if intermediate output was specified, if so, create index of output slices
+		if(pars.meta.numSlices == 0){
+			pars.meta.numSlices = pars.numPlanes;
+		}
+
 #ifdef PRISMATIC_BUILDING_GUI
 		pars.progressbar->signalPotentialUpdate(0, pars.numPlanes);
 #endif

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -55,11 +55,11 @@ namespace Prismatic {
 
 	void setupCoordinates_2(Parameters<PRISMATIC_FLOAT_PRECISION> &pars) {
 		Array1D<PRISMATIC_FLOAT_PRECISION> xR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		xR[0] = pars.meta.scanWindowXMin * pars.tiledCellDim[2];
-		xR[1] = pars.meta.scanWindowXMax * pars.tiledCellDim[2];
+		xR[0] = pars.scanWindowXMin * pars.tiledCellDim[2];
+		xR[1] = pars.scanWindowXMax * pars.tiledCellDim[2];
 		Array1D<PRISMATIC_FLOAT_PRECISION> yR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		yR[0] = pars.meta.scanWindowYMin * pars.tiledCellDim[1];
-		yR[1] = pars.meta.scanWindowYMax * pars.tiledCellDim[1];
+		yR[0] = pars.scanWindowYMin * pars.tiledCellDim[1];
+		yR[1] = pars.scanWindowYMax * pars.tiledCellDim[1];
 
 		vector<PRISMATIC_FLOAT_PRECISION> xp_d = vecFromRange(xR[0], pars.meta.probeStepX, xR[1]);
 		vector<PRISMATIC_FLOAT_PRECISION> yp_d = vecFromRange(yR[0], pars.meta.probeStepY, yR[1]);

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -120,7 +120,7 @@ namespace Prismatic {
 	void createStack_integrate(Parameters<PRISMATIC_FLOAT_PRECISION> &pars) {
 		// create output of a size corresponding to 3D mode (integration)
 
-		pars.output = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{pars.yp.size(), pars.xp.size(), pars.Ndet}});
+		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}
 
 	void setupFourierCoordinates(Parameters<PRISMATIC_FLOAT_PRECISION> &pars) {
@@ -331,15 +331,15 @@ namespace Prismatic {
 
         //save 4D output if applicable
          if (pars.meta.save4DOutput) {
-			std::string section4DFilename = generateFilename(pars, ay, ax);
+			std::string section4DFilename = generateFilename(pars, 1, ay, ax);
 			intOutput.toMRC_f(section4DFilename.c_str());
 		}
 
-//         update output -- ax,ay are unique per thread so this write is thread-safe without a lock
+			//         update output -- ax,ay are unique per thread so this write is thread-safe without a lock
 		auto idx = pars.alphaInd.begin();
 		for (auto counts = intOutput.begin(); counts != intOutput.end(); ++counts) {
 			if (*idx <= pars.Ndet) {
-				pars.output.at(ay, ax, (*idx) - 1) += *counts * pars.scale;
+				pars.output.at(0, ay, ax, (*idx) - 1) += *counts * pars.scale;
 			}
 			++idx;
 		};

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -24,6 +24,7 @@
 #include "fftw3.h"
 #include "utility.h"
 #include "WorkDispatcher.h"
+#include "ArrayND.h"
 
 #ifdef PRISMATIC_BUILDING_GUI
 #include "prism_progressbar.h"
@@ -68,6 +69,15 @@ namespace Prismatic {
 
 		Array1D<PRISMATIC_FLOAT_PRECISION> xp(xp_d, {{xp_d.size()}});
 		Array1D<PRISMATIC_FLOAT_PRECISION> yp(yp_d, {{yp_d.size()}});
+
+		if(pars.meta.saveRealSpaceCoords){
+			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
+			std::string x_name = "real_space_x.mrc"
+			std::string y_name = "real_space_x.mrc"
+			real_mesh.first.toMRC_f(x_name.c_str())
+			real_mesh.second.toMRC_f(y_name.c_str())
+		}
+
 		pars.xp = xp;
 		pars.yp = yp;
 	}

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -72,10 +72,10 @@ namespace Prismatic {
 
 		if(pars.meta.saveRealSpaceCoords){
 			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
-			std::string x_name = "real_space_x.mrc"
-			std::string y_name = "real_space_x.mrc"
-			real_mesh.first.toMRC_f(x_name.c_str())
-			real_mesh.second.toMRC_f(y_name.c_str())
+			std::string x_name = "real_space_x.mrc";
+			std::string y_name = "real_space_y.mrc";
+			real_mesh.first.toMRC_f(x_name.c_str());
+			real_mesh.second.toMRC_f(y_name.c_str());
 		}
 
 		pars.xp = xp;

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -72,8 +72,8 @@ namespace Prismatic {
 
 		if(pars.meta.saveRealSpaceCoords){
 			pair< Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION> > real_mesh = meshgrid(xp,yp);
-			std::string x_name = "real_space_x.mrc";
-			std::string y_name = "real_space_y.mrc";
+			std::string x_name = pars.meta.outputFolder + "real_space_x.mrc";
+			std::string y_name = pars.meta.outputFolder + "real_space_y.mrc";
 			real_mesh.first.toMRC_f(x_name.c_str());
 			real_mesh.second.toMRC_f(y_name.c_str());
 		}

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -120,7 +120,7 @@ namespace Prismatic {
 	void createStack_integrate(Parameters<PRISMATIC_FLOAT_PRECISION> &pars) {
 		// create output of a size corresponding to 3D mode (integration)
 
-		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{pars.yp.size(), pars.xp.size(), pars.Ndet}});
+		pars.output = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{1, pars.yp.size(), pars.xp.size(), pars.Ndet}});
 	}
 
 	void setupFourierCoordinates(Parameters<PRISMATIC_FLOAT_PRECISION> &pars) {
@@ -331,7 +331,7 @@ namespace Prismatic {
 
         //save 4D output if applicable
          if (pars.meta.save4DOutput) {
-			std::string section4DFilename = generateFilename(pars, 1, ay, ax);
+			std::string section4DFilename = generateFilename(pars, 0, ay, ax);
 			intOutput.toMRC_f(section4DFilename.c_str());
 		}
 

--- a/src/PRISM03_calcOutput.cu
+++ b/src/PRISM03_calcOutput.cu
@@ -1679,7 +1679,7 @@ __global__ void scaleReduceS(const cuFloatComplex *permutedScompact_d,
 
 		// output calculation result
 		formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph,
-		                           integratedOutput_ds, ay, ax, pars.imageSizeReduce[0],
+		                           integratedOutput_ds, 0, ay, ax, pars.imageSizeReduce[0],
 		                           pars.imageSizeReduce[1], stream, pars.scale);
 	}
 
@@ -1933,7 +1933,7 @@ __global__ void scaleReduceS(const cuFloatComplex *permutedScompact_d,
 
 		// output calculation result
 		formatOutput_GPU_integrate(pars, psiIntensity_ds, alphaInd_d, output_ph,
-		                           integratedOutput_ds, ay, ax, pars.imageSizeReduce[0],
+		                           integratedOutput_ds, 0, ay, ax, pars.imageSizeReduce[0],
 		                           pars.imageSizeReduce[1], stream, pars.scale);
 	}
 }

--- a/src/PRISM_entry.cpp
+++ b/src/PRISM_entry.cpp
@@ -94,8 +94,8 @@ namespace Prismatic{
 					}
 				}
 			}
-
-			output_image.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
+			std::string image_filename = prismatic_pars.meta.outputFolder + prismatic_pars.meta.filenameOutput;
+			output_image.toMRC_f(image_filename.c_str());
 		}
 
 		if (prismatic_pars.meta.save2DOutput) {
@@ -111,7 +111,7 @@ namespace Prismatic{
 					}
 				}
 			}
-			std::string image_filename = std::string("prism_2Doutput_") + prismatic_pars.meta.filenameOutput;
+			std::string image_filename = prismatic_pars.meta.outputFolder + std::string("prism_2Doutput_") + prismatic_pars.meta.filenameOutput;
 			prism_image.toMRC_f(image_filename.c_str());
 		}
 

--- a/src/PRISM_entry.cpp
+++ b/src/PRISM_entry.cpp
@@ -68,7 +68,7 @@ namespace Prismatic{
 		// calculate remaining frozen phonon configurations
         if (prismatic_pars.meta.numFP > 1) {
             // run the rest of the frozen phonons
-            Array3D<PRISMATIC_FLOAT_PRECISION> net_output(prismatic_pars.output);
+            Array4D<PRISMATIC_FLOAT_PRECISION> net_output(prismatic_pars.output);
             for (auto fp_num = 1; fp_num < prismatic_pars.meta.numFP; ++fp_num){
 	            meta.randomSeed = rand() % 100000;
 				++meta.fpNum;
@@ -84,7 +84,19 @@ namespace Prismatic{
             for (auto&i:net_output) i/=prismatic_pars.meta.numFP;
 	        prismatic_pars.output = net_output;
         }
-        if (prismatic_pars.meta.save3DOutput)prismatic_pars.output.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
+        if (prismatic_pars.meta.save3DOutput){
+			Array3D<PRISMATIC_FLOAT_PRECISION> output_image = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.output.get_dimk(),prismatic_pars.output.get_dimj(),prismatic_pars.output.get_dimi()}});
+			
+			for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y){
+				for (auto x = 0; x < prismatic_pars.output.get_dimj();++x){
+					for (auto b = 0; b < prismatic_pars.output.get_dimi(); ++b){
+						output_image.at(y,x,b) = prismatic_pars.output.at(0,y,x,b);
+					}
+				}
+			}
+
+			output_image.toMRC_f(prismatic_pars.meta.filenameOutput.c_str());
+		}
 
 		if (prismatic_pars.meta.save2DOutput) {
 			size_t lower = std::max((size_t)0, (size_t)(prismatic_pars.meta.integrationAngleMin / prismatic_pars.meta.detectorAngleStep));
@@ -95,7 +107,7 @@ namespace Prismatic{
 			for (auto y = 0; y < prismatic_pars.output.get_dimk(); ++y) {
 				for (auto x = 0; x < prismatic_pars.output.get_dimj(); ++x) {
 					for (auto b = lower; b < upper; ++b) {
-						prism_image.at(y, x) += prismatic_pars.output.at(y, x, b);
+						prism_image.at(y, x) += prismatic_pars.output.at(0, y, x, b);
 					}
 				}
 			}

--- a/src/configure.cpp
+++ b/src/configure.cpp
@@ -67,20 +67,24 @@ namespace Prismatic {
 		// Estimate the amount of memory needed for the various buffers. This is affected by the batch size, which is inputted
 		// by the user but will be adjusted if it is inappropriate (i.e. not enough work per thread).
 		// Figure out the scan configuration to determine how many probes there are to compute
+		size_t scanWindowXMin;
+		size_t scanWindowXMax;
+		size_t scanWindowYMin;
+		size_t scanWindowYMax;
 		if(meta.realSpaceWindow_x){
-			size_t scanWindowXMin = meta.scanWindowXMin_r / (meta.cellDim[2] * meta.tileX);
-			size_t scanWindowXMax = meta.scanWindowXMax_r / (meta.cellDim[2] * meta.tileX);
+			scanWindowXMin = meta.scanWindowXMin_r / (meta.cellDim[2] * meta.tileX);
+			scanWindowXMax = meta.scanWindowXMax_r / (meta.cellDim[2] * meta.tileX);
 		}else{
-			size_t scanWindowXMin = meta.scanWindowXMin;
-			size_t scanWindowXMax = meta.scanWindowXMax;
+			scanWindowXMin = meta.scanWindowXMin;
+			scanWindowXMax = meta.scanWindowXMax;
 		}
 
 		if(meta.realSpaceWindow_y){
-			size_t scanWindowYMin = meta.scanWidnowYMin_r / (meta.cellDim[1] * meta.tileY);
-			size_t scanWindowYMax = meta.scanWidnowYMax_r / (meta.cellDim[1] * meta.tileY);
+			scanWindowYMin = meta.scanWindowYMin_r / (meta.cellDim[1] * meta.tileY);
+			scanWindowYMax = meta.scanWindowYMax_r / (meta.cellDim[1] * meta.tileY);
 		}else{
-			size_t scanWindowYMin = meta.scanWindowYMin;
-			size_t scanWindowYMax = meta.scanWindowYMax;
+			scanWindowYMin = meta.scanWindowYMin;
+			scanWindowYMax = meta.scanWindowYMax;
 		}
 
 		Array1D<PRISMATIC_FLOAT_PRECISION> xR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});

--- a/src/configure.cpp
+++ b/src/configure.cpp
@@ -67,12 +67,28 @@ namespace Prismatic {
 		// Estimate the amount of memory needed for the various buffers. This is affected by the batch size, which is inputted
 		// by the user but will be adjusted if it is inappropriate (i.e. not enough work per thread).
 		// Figure out the scan configuration to determine how many probes there are to compute
+		if(meta.realSpaceWindow_x){
+			size_t scanWindowXMin = meta.scanWindowXMin_r / (meta.cellDim[2] * meta.tileX);
+			size_t scanWindowXMax = meta.scanWindowXMax_r / (meta.cellDim[2] * meta.tileX);
+		}else{
+			size_t scanWindowXMin = meta.scanWindowXMin;
+			size_t scanWindowXMax = meta.scanWindowXMax;
+		}
+
+		if(meta.realSpaceWindow_y){
+			size_t scanWindowYMin = meta.scanWidnowYMin_r / (meta.cellDim[1] * meta.tileY);
+			size_t scanWindowYMax = meta.scanWidnowYMax_r / (meta.cellDim[1] * meta.tileY);
+		}else{
+			size_t scanWindowYMin = meta.scanWindowYMin;
+			size_t scanWindowYMax = meta.scanWindowYMax;
+		}
+
 		Array1D<PRISMATIC_FLOAT_PRECISION> xR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		xR[0] = meta.scanWindowXMin * meta.cellDim[2] * meta.tileX;
-		xR[1] = meta.scanWindowXMax * meta.cellDim[2] * meta.tileX;
+		xR[0] = scanWindowXMin * meta.cellDim[2] * meta.tileX;
+		xR[1] = scanWindowXMax * meta.cellDim[2] * meta.tileX;
 		Array1D<PRISMATIC_FLOAT_PRECISION> yR = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{2}});
-		yR[0] = meta.scanWindowYMin * meta.cellDim[1] * meta.tileY;
-		yR[1] = meta.scanWindowYMax * meta.cellDim[1] * meta.tileY;
+		yR[0] = scanWindowYMin * meta.cellDim[1] * meta.tileY;
+		yR[1] = scanWindowYMax * meta.cellDim[1] * meta.tileY;
 		vector<PRISMATIC_FLOAT_PRECISION> xp_d = vecFromRange(xR[0], meta.probeStepX, xR[1]);
 		vector<PRISMATIC_FLOAT_PRECISION> yp_d = vecFromRange(yR[0], meta.probeStepY, yR[1]);
 

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -193,6 +193,8 @@ namespace Prismatic {
         f << "--probe-ytilt:" << meta.probeYtilt * 1000 << '\n';
         f << "--scan-window-x:" << meta.scanWindowXMin << ' ' << meta.scanWindowXMax << '\n';
         f << "--scan-window-y:" << meta.scanWindowYMin << ' ' << meta.scanWindowYMax << '\n';
+        f << "--scan-window-xr:" << meta.scanWindowXMin_r << ' ' << meta.scanWindowXMax_r << '\n';
+        f << "--scan-window-yr:" << meta.scanWindowYMin_r << ' ' << meta.scanWindowYMax_r << '\n';
         f << "--random-seed:" << meta.randomSeed << '\n';
         if (meta.includeThermalEffects){
             f << "--thermal-effects:1\n";
@@ -211,6 +213,16 @@ namespace Prismatic {
             f << "--save-4D-output:1\n";
         } else {
             f << "--save-4D-output:0\n";
+        }
+        if (meta.savePotentialSlices){
+            f << "--save-potential-slices:1\n";
+        } else {
+            f << "--save-potential-slices:0\n";
+        }
+        if (meta.saveRealSpaceCoords){
+            f << "--save-real-space-coords:1\n";
+        } else {
+            f << "--save-real-space-coords:0\n";
         }
         if (meta.includeOccupancy) {
             f << "--occupancy:1\n";
@@ -642,6 +654,20 @@ namespace Prismatic {
             return false;
         }
         meta.filenameOutput = std::string((*argv)[1]);
+        //cout <<"meta.filenameAtoms = " << meta.filenameAtoms << endl;
+        argc-=2;
+        argv[0]+=2;
+        return true;
+    };
+
+    bool parse_of(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+                        int& argc, const char*** argv){
+
+        if (argc < 2){
+            cout << "No folder provided for -of (syntax is -of /path/)\n";
+            return false;
+        }
+        meta.outputFolder = std::string((*argv)[1]);
         //cout <<"meta.filenameAtoms = " << meta.filenameAtoms << endl;
         argc-=2;
         argv[0]+=2;
@@ -1095,6 +1121,7 @@ namespace Prismatic {
             {"--interp-factor-x", parse_fx}, {"-fx", parse_fx},
             {"--interp-factor-y", parse_fy}, {"-fy", parse_fy},
             {"--output-file", parse_o}, {"-o", parse_o},
+            {"--output-folder", parse_of}, {"-of", parse_of},
             {"--num-threads", parse_j}, {"-j", parse_j},
             {"--num-streams", parse_S}, {"-S", parse_S},
             {"--slice-thickness", parse_s}, {"-s", parse_s},

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -47,7 +47,8 @@ namespace Prismatic {
 		        "* --num-gpus (-g) value : number of GPUs to use. A runtime check is performed to check how many are actually available, and the minimum of these two numbers is used. (default: " << defaults.numGPUs << ")\n" <<
                 "* --slice-thickness (-s) thickness : thickness of each slice of projected potential (in Angstroms) (default: " << defaults.sliceThickness << ")\n" <<
                 "* --num-slices (-ns) number of slices: in multislice mode, number of slices before intermediate output is given (default: " << defaults.numSlices << ")\n" <<
-		        "* --batch-size (-b) value : number of probes/beams to propagate simultaneously for both CPU and GPU workers. (default: " << defaults.batchSizeCPU << ")\n" <<
+		        "* --zstart-slices (-zs) value: in multislice mode, depth Z at which to begin intermediate output (default: " << defaults.zStart << ")\n" <<
+                "* --batch-size (-b) value : number of probes/beams to propagate simultaneously for both CPU and GPU workers. (default: " << defaults.batchSizeCPU << ")\n" <<
 		        "* --batch-size-cpu (-bc) value : number of probes/beams to propagate simultaneously for CPU workers. (default: " << defaults.batchSizeCPU << ")\n" <<
 		        "* --batch-size-gpu (-bg) value : number of probes/beams to propagate simultaneously for GPU workers. (default: " << defaults.batchSizeGPU << ")\n" <<
                 "* --help(-h) : print information about the available options\n"
@@ -162,6 +163,7 @@ namespace Prismatic {
         f << "--num-FP:" << meta.numFP << '\n';
         f << "--slice-thickness:" << meta.sliceThickness<< '\n';
         f << "--num-slices:" << meta.numSlices<< '\n';
+        f << "--zstart-slices:" << meta.zStart<< '\n';
         f << "--energy:" << meta.E0 / 1000 << '\n';
         f << "--alpha-max:" << meta.alphaBeamMax * 1000 << '\n';
         f << "--batch-size-cpu:" << meta.batchSizeTargetCPU << '\n';
@@ -560,6 +562,22 @@ namespace Prismatic {
         }
         if ( (meta.numSlices = atoi((*argv)[1])) < 0){
             cout << "Invalid value \"" << (*argv)[1] << "\" provided for number of slices (syntax is -ns num_slices)\n";
+            return false;
+        }
+        argc-=2;
+        argv[0]+=2;
+        return true;
+    };
+
+    bool parse_zs(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+                        int& argc, const char*** argv){
+
+        if (argc < 2){
+            cout << "No value for beginning intermediate output depth provided (syntax is -zs z_start (in Angstroms))\n";
+            return false;
+        }
+        if ( (meta.numSlices = atoi((*argv)[1])) < 0){
+            cout << "Invalid value \"" << (*argv)[1] << "\" provided for beginning intermediate output depth (syntax is -zs z_start (in Angstroms))\n";
             return false;
         }
         argc-=2;
@@ -993,6 +1011,7 @@ namespace Prismatic {
             {"--num-streams", parse_S}, {"-S", parse_S},
             {"--slice-thickness", parse_s}, {"-s", parse_s},
             {"--num-slices",parse_ns},{"-ns",parse_ns},
+            {"--zstart-slices",parse_zs},{"-zs",parse_zs},
             {"--num-gpus", parse_g}, {"-g", parse_g},
             {"--batch-size", parse_b}, {"-b", parse_b},
             {"--batch-size-cpu", parse_bc}, {"-bc", parse_bc},

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -576,7 +576,7 @@ namespace Prismatic {
             cout << "No value for beginning intermediate output depth provided (syntax is -zs z_start (in Angstroms))\n";
             return false;
         }
-        if ( (meta.numSlices = atoi((*argv)[1])) < 0){
+        if ( (meta.zStart = atoi((*argv)[1])) < 0){
             cout << "Invalid value \"" << (*argv)[1] << "\" provided for beginning intermediate output depth (syntax is -zs z_start (in Angstroms))\n";
             return false;
         }

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -83,8 +83,9 @@ namespace Prismatic {
                 "* --occupancy (-oc) bool : whether or not to consider occupancy values for likelihood of atoms existing at each site (default: True)\n" <<
 		        "* --save-2D-output (-2D) ang_min ang_max : save the 2D STEM image integrated between ang_min and ang_max (in mrads) (default: Off)\n" <<
 	            "* --save-3D-output (-3D) bool=true : Also save the 3D output at the detector for each probe (3D output mode) (default: On)\n" <<
-                "* --save-4D-output (-4D) bool=false : Also save the 4D output at the detector for each probe (4D output mode) (default: Off)\n";
-                "* --save-real-space-coords (-rsc) bool=false : Also save the real space coordinates of the probe dimensions (default: Off)\n";
+                "* --save-4D-output (-4D) bool=false : Also save the 4D output at the detector for each probe (4D output mode) (default: Off)\n" <<
+                "* --save-real-space-coords (-rsc) bool=false : Also save the real space coordinates of the probe dimensions (default: Off)\n" <<
+                "* --save-potential-slices (-ps) bool=false : Also save the calculated potential slices (default: Off)\n";
     }
 
 

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -1062,6 +1062,18 @@ namespace Prismatic {
         return true;
     };
 
+    bool parse_ps(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+                 int& argc, const char*** argv){
+        if (argc < 2){
+            cout << "No value provided for -ps (syntax is -ps bool)\n";
+            return false;
+        }
+        meta.savePotentialSlices = std::string((*argv)[1]) == "0" ? false : true;
+        argc-=2;
+        argv[0]+=2;
+        return true;
+    };
+
     bool parseInputs(Metadata<PRISMATIC_FLOAT_PRECISION> &meta,
                      int &argc, const char ***argv) {
         if (argc==1)return true; // case of no inputs to parse
@@ -1124,7 +1136,8 @@ namespace Prismatic {
             {"--save-2D-output", parse_2D}, {"-2D", parse_2D},
             {"--save-3D-output", parse_3D}, {"-3D", parse_3D},
             {"--save-4D-output", parse_4D}, {"-4D", parse_4D},
-            {"--save-real-space-coords",parse_rsc}, {"-rsc",parse_rsc}
+            {"--save-real-space-coords",parse_rsc}, {"-rsc",parse_rsc},
+            {"--save-potential-slices",parse_ps},{"-ps",parse_ps}
     };
     bool parseInput(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
                            int& argc, const char*** argv){

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -558,7 +558,7 @@ namespace Prismatic {
             cout << "No number of slices provided for intermediate output (syntax is -ns num_slices)\n";
             return false;
         }
-        if ( (meta.numSlices = atoi((*argv)[1])) == 0){
+        if ( (meta.numSlices = atoi((*argv)[1])) < 0){
             cout << "Invalid value \"" << (*argv)[1] << "\" provided for number of slices (syntax is -ns num_slices)\n";
             return false;
         }

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -84,6 +84,7 @@ namespace Prismatic {
 		        "* --save-2D-output (-2D) ang_min ang_max : save the 2D STEM image integrated between ang_min and ang_max (in mrads) (default: Off)\n" <<
 	            "* --save-3D-output (-3D) bool=true : Also save the 3D output at the detector for each probe (3D output mode) (default: On)\n" <<
                 "* --save-4D-output (-4D) bool=false : Also save the 4D output at the detector for each probe (4D output mode) (default: Off)\n";
+                "* --save-real-space-coords (-rsc) bool=false : Also save the real space coordinates of the probe dimensions (default: Off)\n";
     }
 
 
@@ -1049,6 +1050,18 @@ namespace Prismatic {
         return true;
     };
 
+    bool parse_rsc(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+                 int& argc, const char*** argv){
+        if (argc < 2){
+            cout << "No value provided for -rsc (syntax is -rsc bool)\n";
+            return false;
+        }
+        meta.saveRealSpaceCoords = std::string((*argv)[1]) == "0" ? false : true;
+        argc-=2;
+        argv[0]+=2;
+        return true;
+    };
+
     bool parseInputs(Metadata<PRISMATIC_FLOAT_PRECISION> &meta,
                      int &argc, const char ***argv) {
         if (argc==1)return true; // case of no inputs to parse
@@ -1110,7 +1123,8 @@ namespace Prismatic {
             {"--occupancy", parse_oc}, {"-oc", parse_oc},
             {"--save-2D-output", parse_2D}, {"-2D", parse_2D},
             {"--save-3D-output", parse_3D}, {"-3D", parse_3D},
-            {"--save-4D-output", parse_4D}, {"-4D", parse_4D}
+            {"--save-4D-output", parse_4D}, {"-4D", parse_4D},
+            {"--save-real-space-coords",parse_rsc}, {"-rsc",parse_rsc}
     };
     bool parseInput(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
                            int& argc, const char*** argv){

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -46,6 +46,7 @@ namespace Prismatic {
                 "* --num-streams (-S) value : number of CUDA streams to create per GPU (default: " << defaults.numStreamsPerGPU << ")\n" <<
 		        "* --num-gpus (-g) value : number of GPUs to use. A runtime check is performed to check how many are actually available, and the minimum of these two numbers is used. (default: " << defaults.numGPUs << ")\n" <<
                 "* --slice-thickness (-s) thickness : thickness of each slice of projected potential (in Angstroms) (default: " << defaults.sliceThickness << ")\n" <<
+                "* --num-slices (-ns) number of slices: in multislice mode, number of slices before intermediate output is given (default: " << defaults.numSlices << ")\n" <<
 		        "* --batch-size (-b) value : number of probes/beams to propagate simultaneously for both CPU and GPU workers. (default: " << defaults.batchSizeCPU << ")\n" <<
 		        "* --batch-size-cpu (-bc) value : number of probes/beams to propagate simultaneously for CPU workers. (default: " << defaults.batchSizeCPU << ")\n" <<
 		        "* --batch-size-gpu (-bg) value : number of probes/beams to propagate simultaneously for GPU workers. (default: " << defaults.batchSizeGPU << ")\n" <<
@@ -160,6 +161,7 @@ namespace Prismatic {
         f << "--potential-bound:" << meta.potBound << '\n';
         f << "--num-FP:" << meta.numFP << '\n';
         f << "--slice-thickness:" << meta.sliceThickness<< '\n';
+        f << "--num-slices:" << meta.numSlices<< '\n';
         f << "--energy:" << meta.E0 / 1000 << '\n';
         f << "--alpha-max:" << meta.alphaBeamMax * 1000 << '\n';
         f << "--batch-size-cpu:" << meta.batchSizeTargetCPU << '\n';
@@ -542,6 +544,22 @@ namespace Prismatic {
         }
         if ( (meta.sliceThickness = atof((*argv)[1])) == 0){
             cout << "Invalid value \"" << (*argv)[1] << "\" provided for slice_thickness (syntax is -s slice_thickness (in Angstroms))\n";
+            return false;
+        }
+        argc-=2;
+        argv[0]+=2;
+        return true;
+    };
+
+    bool parse_ns(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+                        int& argc, const char*** argv){
+
+        if (argc < 2){
+            cout << "No number of slices provided for intermediate output (syntax is -ns num_slices)\n";
+            return false;
+        }
+        if ( (meta.numSlices = atoi((*argv)[1])) == 0){
+            cout << "Invalid value \"" << (*argv)[1] << "\" provided for number of slices (syntax is -ns num_slices)\n";
             return false;
         }
         argc-=2;
@@ -974,6 +992,7 @@ namespace Prismatic {
             {"--num-threads", parse_j}, {"-j", parse_j},
             {"--num-streams", parse_S}, {"-S", parse_S},
             {"--slice-thickness", parse_s}, {"-s", parse_s},
+            {"--num-slices",parse_ns},{"-ns",parse_ns},
             {"--num-gpus", parse_g}, {"-g", parse_g},
             {"--batch-size", parse_b}, {"-b", parse_b},
             {"--batch-size-cpu", parse_bc}, {"-bc", parse_bc},

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -76,6 +76,8 @@ namespace Prismatic {
                 "* --probe-semiangle (-sa) value : maximum probe semiangle (in mrad) (default: " << 1000*defaults.probeSemiangle << ")\n" <<
                 "* --scan-window-x (-wx) min max : size of the window to scan the probe in X (in fractional coordinates between 0 and 1) (default: " << defaults.scanWindowXMin << " " << defaults.scanWindowXMax << ")\n" <<
                 "* --scan-window-y (-wy) min max : size of the window to scan the probe in Y (in fractional coordinates between 0 and 1) (default: " << defaults.scanWindowYMin << " " << defaults.scanWindowYMax << ")\n" <<
+                "* --scan-window-xr (-wxr) min max : size of the window to scan the probe in X (in Angstroms) (defaults to fractional coordinates) " << ")\n" <<
+                "* --scan-window-yr (-wyr) min max : size of the window to scan the probe in Y (in Angstroms) (defaults to fractional coordiantes) " << ")\n" <<
                 "* --num-FP (-F) value : number of frozen phonon configurations to calculate (default: " << defaults.numFP << ")\n" <<
 		        "* --thermal-effects (-te) bool : whether or not to include Debye-Waller factors (thermal effects) (default: True)\n" <<
                 "* --occupancy (-oc) bool : whether or not to consider occupancy values for likelihood of atoms existing at each site (default: True)\n" <<
@@ -919,6 +921,66 @@ namespace Prismatic {
         return true;
     };
 
+	bool parse_wxr(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+	             int& argc, const char*** argv){
+		if (argc < 3){
+			cout << "Invalid window provided for -wxr (syntax is -wxr min max (in Angstroms))\n";
+			return false;
+		}
+		PRISMATIC_FLOAT_PRECISION minval, maxval;
+		minval = (PRISMATIC_FLOAT_PRECISION)atof((*argv)[1]);
+        maxval = (PRISMATIC_FLOAT_PRECISION)atof((*argv)[2]);
+
+		if ( (minval == 0) & (std::string((*argv)[1]) != "0")){
+			cout << "Invalid lower bound \"" << (*argv)[1] << "\" provided for scan window Xr (syntax is -wxr min max (in Angstroms))\n";
+			return false;
+		}
+		if ( (maxval == 0) & (std::string((*argv)[2]) != "0")){
+			cout << "Invalid upper bound \"" << (*argv)[2] << "\" provided for scan window Xr (syntax is -wxr min max (in Angstroms))\n";
+			return false;
+		}
+        if (maxval < minval){
+            cout << "The provided lower bound(" << minval << ") for the X scan in real space is greater than the maximum(" << maxval <<")." << endl;
+         return false;
+        }
+        meta.scanWindowXMin_r = minval;
+        meta.scanWindowXMax_r = maxval;
+        meta.realSpaceWindow_x = true;
+		argc-=3;
+		argv[0]+=3;
+		return true;
+	};
+
+	bool parse_wyr(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
+	             int& argc, const char*** argv){
+		if (argc < 3){
+			cout << "Invalid window provided for -wyr (syntax is -wyr min max (in Angstroms))\n";
+			return false;
+		}
+		PRISMATIC_FLOAT_PRECISION minval, maxval;
+		minval = (PRISMATIC_FLOAT_PRECISION)atof((*argv)[1]);
+        maxval = (PRISMATIC_FLOAT_PRECISION)atof((*argv)[2]);
+
+		if ( (minval == 0) & (std::string((*argv)[1]) != "0")){
+			cout << "Invalid lower bound \"" << (*argv)[1] << "\" provided for scan window Yr (syntax is -wyr min max (in Angstroms))\n";
+			return false;
+		}
+		if ( (maxval == 0) & (std::string((*argv)[2]) != "0")){
+			cout << "Invalid upper bound \"" << (*argv)[2] << "\" provided for scan window Yr (syntax is -wyr min max (in Angstroms))\n";
+			return false;
+		}
+        if (maxval < minval){
+            cout << "The provided lower bound(" << minval << ") for the Y scan in real space is greater than the maximum(" << maxval <<")." << endl;
+         return false;
+        }
+        meta.scanWindowYMin_r = minval;
+        meta.scanWindowYMax_r = maxval;
+        meta.realSpaceWindow_y = true;
+		argc-=3;
+		argv[0]+=3;
+		return true;
+	};
+
 	bool parse_te(Metadata<PRISMATIC_FLOAT_PRECISION>& meta,
 	              int& argc, const char*** argv){
 		if (argc < 2){
@@ -1040,6 +1102,8 @@ namespace Prismatic {
             {"--probe-semiangle", parse_sa}, {"-sa", parse_sa},
             {"--scan-window-y", parse_wy}, {"-wy", parse_wy},
             {"--scan-window-x", parse_wx}, {"-wx", parse_wx},
+            {"--scan-window-yr", parse_wyr}, {"-wyr", parse_wyr},
+            {"--scan-window-xr", parse_wxr}, {"-wxr", parse_wxr},
             {"--tile-uc", parse_t}, {"-t", parse_t},
             {"--num-FP", parse_F}, {"-F", parse_F},
             {"--thermal-effects", parse_te}, {"-te", parse_te},

--- a/src/utility.cu
+++ b/src/utility.cu
@@ -453,7 +453,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 		                           cudaMemcpyDeviceToHost,
 		                           stream));
 
-		if (pars.meta.algorthm == Algorithm::Multislice){
+		if (pars.meta.algorithm == Prismatic::Algorithm::Multislice){
             Prismatic::Array2D<PRISMATIC_FLOAT_PRECISION>  finalImage = Prismatic::zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
             {{pars.psiProbeInit.get_dimj()/2,pars.psiProbeInit.get_dimi()/2}});
             {

--- a/src/utility.cu
+++ b/src/utility.cu
@@ -452,7 +452,26 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 		                           pars.psiProbeInit.size() * sizeof(PRISMATIC_FLOAT_PRECISION),
 		                           cudaMemcpyDeviceToHost,
 		                           stream));
+
+		if (pars.meta.algorthm == Algorithm::Multislice){
+            Prismatic::Array2D<PRISMATIC_FLOAT_PRECISION>  finalImage = Prismatic::zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
+            {{pars.psiProbeInit.get_dimj()/2,pars.psiProbeInit.get_dimi()/2}});
+            {
+                long offset_x = pars.psiProbeInit.get_dimi() / 4;
+                long offset_y = pars.psiProbeInit.get_dimj() / 4;
+                long ndimy = (long) pars.psiProbeInit.get_dimj();
+                long ndimx = (long) pars.psiProbeInit.get_dimi();
+                for (long y = 0; y < pars.psiProbeInit.get_dimj() / 2; ++y) {
+                    for (long x = 0; x < pars.psiProbeInit.get_dimi() / 2; ++x) {
+                        finalImage.at(y, x) = currentImage.at(((y - offset_y) % ndimy + ndimy) % ndimy,
+                                                    ((x - offset_x) % ndimx + ndimx) % ndimx);
+                    }
+                }
+			}
+		finalImage.toMRC_f(section4DFilename.c_str());
+        }else{                     
 		currentImage.toMRC_f(section4DFilename.c_str());
+        }
 	}
 //		cudaSetDeviceFlags(cudaDeviceBlockingSync);
 

--- a/src/utility.cu
+++ b/src/utility.cu
@@ -430,7 +430,8 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
                                 PRISMATIC_FLOAT_PRECISION *psiIntensity_ds,
                                 const PRISMATIC_FLOAT_PRECISION *alphaInd_d,
                                 PRISMATIC_FLOAT_PRECISION *output_ph,
-                                PRISMATIC_FLOAT_PRECISION *integratedOutput_ds,
+								PRISMATIC_FLOAT_PRECISION *integratedOutput_ds,
+								const size_t currentSlice,
                                 const size_t ay,
                                 const size_t ax,
                                 const size_t& dimj,
@@ -443,7 +444,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 		// This section could be improved. It currently makes a new 2D array, copies to it, and
 		// then saves the image. This allocates arrays multiple times unneccessarily, and the allocated
 		// memory isn't pinned, so the memcpy is not asynchronous.
-		std::string section4DFilename = generateFilename(pars, ay, ax);
+		std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
 		Prismatic::Array2D<PRISMATIC_FLOAT_PRECISION> currentImage = Prismatic::zeros_ND<2, PRISMATIC_FLOAT_PRECISION>(
 				{{pars.psiProbeInit.get_dimj(), pars.psiProbeInit.get_dimi()}});
 		cudaErrchk(cudaMemcpyAsync(&currentImage[0],
@@ -513,7 +514,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 	cudaErrchk(cudaStreamSynchronize(stream));
 	//const size_t stack_start_offset = ay*pars.output.get_dimk()*pars.output.get_dimj()+ ax*pars.output.get_dimj();
 	const size_t stack_start_offset =
-			ay * pars.output.get_dimj() * pars.output.get_dimi() + ax * pars.output.get_dimi();
+			currentSlice * pars.output.get_dimk() * pars.output.get_dimj() * pars.output.get_dimi() + ay * pars.output.get_dimj() * pars.output.get_dimi() + ax * pars.output.get_dimi();
 	memcpy(&pars.output[stack_start_offset], output_ph, num_integration_bins * sizeof(PRISMATIC_FLOAT_PRECISION));
 }
 


### PR DESCRIPTION
From my email to Colin and AJ
-----
"Fixes":

- Crop the 4D output of Multislice implementation
- - Reapplied the anti-alias masking operation to the multislice 4D output so as to output only the relevant, non-zero padded image*

*I think this shifts the preferred convention of the 4D output images such that the zero frequencies are in the centers of the output matrices instead of the outside. I personally preferred this, as it removed a processing step for the experiments I did, but this would require a slight alteration to remain consistent with the original prismatic implementation.

New options:
- Intermediate output at arbitrary depth**
- - Specify intermediate output to be used with --num-slices N or -ns N where N is the number of potential slices to propagate through between each series of output images, defaults to a single output
- - - All outputs are guaranteed to be equally spaced except the final layer. If the final layer is not an integer multiple of N*slice thickness, then that layer also gets its own output.
- - Specify an arbitrary depth for the first intermediate output to begin with --zstart-slices Z or -zs Z where Z is the depth in Angstroms from the top of the sample with respect to incident beam, defaults to top of the sample
- - - If the specified depth is between two outputs as specified by -ns, intermediate output will begin at the first output after the arbitary depth
- - ex: A 40x40x41 Angstrom simulation cell with potential slices that are 2 A in depth has simulation options -ns 2 and -zs 12. There will be outputs at 12 A, 16 A, 20 A, ..., 36 A, 40 A, 41 A
- - ex 2: The same simulation as before, however, this time, the -zs option is -zs 10. There will still be outputs at 12 A, 16 A, 20 A, ..., 36 A, 40 A, 41 A
- - note: with combined use of 4D output, intermediate output, and many frozen phonons, this could certainly blow up a filesystem, and if other users typically work on smaller work stations, could certainly eat up signficant portions of memory, would be cautious,
- Specify scan window in real space coordinates
- - Using --scan-window-yr/--scan-window-xr and -wyr/-wxr as opposed to the default options -wy/-wx allows one to specify real space coordinates in Angstroms as the bounds for the scan window instead of fractional coordinates
- - -If the input coordinates are out of bounds, they will default to the max fractional coordinate
- Specify a target output folder different than current directory
- - Using --output-folder or -of, can specify a path to a pre-existing output folder
- - - Does not forcibly create the output folder, if the output folder does not exist at the time of the simulation, I believe the output would typically not get written
- Option to save the potential slices and probe coordinates
- - Using --save-potential-slices or -ps, one can save the calculated potential array
- - Using --save-real-space-coords or -rsc, one can save the real space coordinates of the probe positions into two files, one as a grid for X and one as a grid for Y


**This was the biggest overall change, as it required me to change the dimensionality of the main output array, propagating changes in many places throughout the source.