### PR TITLE
Fix default param file saving on windows

### DIFF
--- a/src/go.cpp
+++ b/src/go.cpp
@@ -33,7 +33,7 @@ namespace Prismatic{
 
 #ifdef _WIN32
 		char* appdata = getenv("APPDATA");
-		Prismatic::writeParamFile(meta, std::string(appdata) + "\prismatic_gui_params.txt");
+		Prismatic::writeParamFile(meta, std::string(appdata) + "\\prismatic_gui_params.txt");
 #else
 		char* appdata = getenv("HOME");
 		Prismatic::writeParamFile(meta, std::string(appdata) + "/prismatic_gui_params.txt");


### PR DESCRIPTION
The Windows path for saving the parameter file should have two backslashes rather than just one.
Before/After PR:
```python
>>> import pyprismatic as pr
>>> pr.demo()
# The following is the last line in the simulation
Writing simulation parameters to file C:\Users\thomasaar\AppData\Roamingprismatic_gui_params.txt
Writing simulation parameters to file C:\Users\thomasaar\AppData\Roaming\prismatic_gui_params.txt
```
