### PR TITLE
4D output bug fixing and crop feature addition

### DIFF
--- a/Qt/prism_qthreads.cpp
+++ b/Qt/prism_qthreads.cpp
@@ -615,7 +615,7 @@ void FullPRISMCalcThread::run()
             }
         }
 
-        Prismatic::writeRealSlice(DPC_data, &DPC_slice[0], mdims);
+        Prismatic::writeDatacube3D(DPC_data, &DPC_slice[0], mdims);
         DPC_data.close();
         dataGroup.close();
     }
@@ -878,7 +878,7 @@ void FullMultisliceCalcThread::run()
                 }
             }
 
-            Prismatic::writeRealSlice(DPC_data, &DPC_slice[0], mdims);
+            Prismatic::writeDatacube3D(DPC_data, &DPC_slice[0], mdims);
             DPC_data.close();
             dataGroup.close();
         }

--- a/Qt/prism_qthreads.cpp
+++ b/Qt/prism_qthreads.cpp
@@ -37,6 +37,8 @@ void PotentialThread::run()
 {
     // create parameters
     Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> params(meta, progressbar);
+    //prevent it from trying to write to a non-existing H5 file
+    params.meta.savePotentialSlices = false;
     progressbar->signalDescriptionMessage("Computing projected potential");
 
     {
@@ -117,6 +119,9 @@ void ProbeThread::run()
     //    Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> params(meta);
 
     //    Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> params_multi(params);
+    params.meta.save4DOutput = false;
+    params.meta.savePotentialSlices = false;
+    params.meta.saveDPC_CoM = false;
 
     QMutexLocker calculationLocker(&this->parent->calculationLock);
 
@@ -176,6 +181,9 @@ void ProbeThread::run()
 
     std::pair<Prismatic::Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>>, Prismatic::Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>>> prism_probes, multislice_probes;
     Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> params_multi(params);
+    params_multi.meta.save4DOutput = false;
+    params_multi.meta.savePotentialSlices = false;
+    params_multi.meta.saveDPC_CoM = false;
 
     // setup and calculate PRISM probe
     Prismatic::setupCoordinates_2(params);

--- a/Qt/prismmainwindow.cpp
+++ b/Qt/prismmainwindow.cpp
@@ -49,7 +49,7 @@ std::string get_default_parameter_filename() {
 
 #ifdef _WIN32
 	char* appdata = getenv("APPDATA");
-	return std::string(appdata) + "\prismatic_gui_params.txt";
+	return std::string(appdata) + "\\prismatic_gui_params.txt";
 #else
 	char* appdata = getenv("HOME");
 	return std::string(appdata) + "/prismatic_gui_params.txt";

--- a/include/meta.h
+++ b/include/meta.h
@@ -327,7 +327,7 @@ namespace Prismatic{
         if(scanWindowYMin_r != other.scanWindowYMin_r)return false;
         if(scanWindowYMax_r != other.scanWindowYMax_r)return false;
         if(randomSeed != other.randomSeed)return false;
-        if(crop4Damax != other.crop4Doutput)return false;
+        if(crop4Damax != other.crop4Damax)return false;
         if(includeThermalEffects != other.includeThermalEffects)return false;
         if(includeOccupancy != other.includeOccupancy)return false;
         if(alsoDoCPUWork != other.alsoDoCPUWork)return false;

--- a/include/meta.h
+++ b/include/meta.h
@@ -22,316 +22,328 @@
 namespace Prismatic{
 
     enum class StreamingMode{Stream, SingleXfer, Auto};
-	template <class T>
-	class Metadata{
-	public:
-		void toString();
-		bool operator==(const Metadata<T> other);
-	
-		Metadata(){
-			interpolationFactorY  = 4;
-			interpolationFactorX  = 4;
-			filenameAtoms         = "/path/to/atoms.txt";
-			filenameOutput        = "output.h5";
-			outputFolder          = "";
-			realspacePixelSize[0] = 0.1;
-			realspacePixelSize[1] = 0.1;
-			potBound              = 2.0;
-			numFP                 = 1;
-			fpNum                 = 1;
-			sliceThickness        = 2.0;
-			numSlices             = 0; 
-			zStart                = 0.0;
-			cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
-			tileX                 = 1;
-			tileY                 = 1;
-			tileZ                 = 1;
-			E0                    = 80e3;
-			alphaBeamMax          = 24 / 1000.0;
-			numGPUs               = 4;
-			numStreamsPerGPU      = 3;
-			numThreads            = 12;
-			batchSizeTargetCPU    = 1;
-			batchSizeTargetGPU    = 1;
-			batchSizeCPU          = batchSizeTargetCPU;
-			batchSizeGPU          = batchSizeTargetGPU;
-			earlyCPUStopCount     = 100; // relative speed of job completion between gpu and cpu, used to determine early stopping point for cpu work
-			probeStepX            = 0.25;
-			probeStepY            = 0.25;
-			probeDefocus          = 0.0;
-			C3                    = 0.0;
-			C5                    = 0.0;
-			probeSemiangle        = 20.0 / 1000;
-			detectorAngleStep     = 1.0 / 1000;
-			probeXtilt            = 0;
-			probeYtilt            = 0;
-			scanWindowXMin        = 0.0;
-			scanWindowXMax        = 0.99999;
-			scanWindowYMin        = 0.0;
-			scanWindowYMax        = 0.99999;
-			scanWindowXMin_r      = 0.0; //realspace alternatives to setting scan window
-			scanWindowXMax_r      = 0.0;
-			scanWindowYMin_r      = 0.0;
-			scanWindowYMax_r      = 0.0;
-			srand(time(0));
-			randomSeed            = rand() % 100000;
-			algorithm             = Algorithm::PRISM;
-			includeThermalEffects = true;
-			includeOccupancy      = true;
-			alsoDoCPUWork         = true;
-			save2DOutput          = false;
-			save3DOutput          = true;
-			save4DOutput          = false;
-			saveDPC_CoM           = false;
-			saveRealSpaceCoords   = false;
-			savePotentialSlices   = false;
-			userSpecifiedCelldims = false;
-			realSpaceWindow_x     = false;
-			realSpaceWindow_y     = false;
-			integrationAngleMin   = 0;
-			integrationAngleMax   = detectorAngleStep;
-			transferMode          = StreamingMode::Auto;
-			nyquistSampling		  = false;
-		}
-		size_t interpolationFactorY; // PRISM f_y parameter
-		size_t interpolationFactorX; // PRISM f_x parameter
-		std::string filenameAtoms; // filename of txt file containing atoms (x,y,z,Z CSV format -- one atom per line)
-		std::string filenameOutput;// filename of output image
-		std::string outputFolder; // folder of output images
-		T realspacePixelSize[2]; // pixel size
-		T potBound; // bounding integration radius for potential calculation
-		size_t numFP; // number of frozen phonon configurations to compute
-		size_t fpNum; // current frozen phonon number
-		T sliceThickness; // thickness of slice in Z
-		size_t numSlices; //number of slices to itereate through in multislice before giving an output
-		T zStart; //Z coordinate of cell where multislice intermediate output will begin outputting
-		T probeStepX;
-		T probeStepY;
-		std::vector<T> cellDim; // this is z,y,x format
-		size_t tileX, tileY, tileZ; // how many unit cells to repeat in x,y,z
-		size_t batchSizeTargetCPU; // desired number of probes/beams to propagate simultaneously for CPU
-		size_t batchSizeTargetGPU; // desired number of probes/beams to propagate simultaneously for GPU
-		size_t batchSizeCPU; // actual number of probes/beams to propagate simultaneously for CPU
-		size_t batchSizeGPU; // actual number of probes/beams to propagate simultaneously for GPU
-		T earlyCPUStopCount;
-		T E0; // electron energy
-		T alphaBeamMax; // max semi angle for probe
-		T detectorAngleStep;
-		T probeDefocus;
-		T C3;
-		T C5;
-		T probeSemiangle;
-		T probeXtilt;
-		T probeYtilt;
-		T scanWindowXMin;
-		T scanWindowXMax;
-		T scanWindowYMin;
-		T scanWindowYMax;
-		T scanWindowXMin_r;
-		T scanWindowXMax_r;
-		T scanWindowYMin_r;
-		T scanWindowYMax_r;
-		T randomSeed;
-		size_t numThreads; // number of CPU threads to use
-		size_t numGPUs; // number of GPUs to use
-		size_t numStreamsPerGPU; // number of CUDA streams to use per GPU
-		Algorithm algorithm;
-		bool includeThermalEffects;
-		bool includeOccupancy;
-		bool alsoDoCPUWork; // what fraction of computation to do on the cpu vs gpu
-		bool save2DOutput;
-		T integrationAngleMin;
-		T integrationAngleMax;
-		bool save3DOutput;
-		bool save4DOutput;
-		bool saveDPC_CoM;
-		bool saveRealSpaceCoords;
-		bool savePotentialSlices;
-		bool userSpecifiedCelldims;
-		bool realSpaceWindow_x;
-		bool realSpaceWindow_y;
-		bool nyquistSampling;
-		StreamingMode transferMode;
+    template <class T>
+    class Metadata{
+    public:
+        void toString();
+        bool operator==(const Metadata<T> other);
 
-	};
+        Metadata(){
+            interpolationFactorY  = 4;
+            interpolationFactorX  = 4;
+            filenameAtoms         = "/path/to/atoms.txt";
+            filenameOutput        = "output.h5";
+            outputFolder          = "";
+            realspacePixelSize[0] = 0.1;
+            realspacePixelSize[1] = 0.1;
+            potBound              = 2.0;
+            numFP                 = 1;
+            fpNum                 = 1;
+            sliceThickness        = 2.0;
+            numSlices             = 0; 
+            zStart                = 0.0;
+            cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
+            tileX                 = 1;
+            tileY                 = 1;
+            tileZ                 = 1;
+            E0                    = 80e3;
+            alphaBeamMax          = 24 / 1000.0;
+            numGPUs               = 4;
+            numStreamsPerGPU      = 3;
+            numThreads            = 12;
+            batchSizeTargetCPU    = 1;
+            batchSizeTargetGPU    = 1;
+            batchSizeCPU          = batchSizeTargetCPU;
+            batchSizeGPU          = batchSizeTargetGPU;
+            earlyCPUStopCount     = 100; // relative speed of job completion between gpu and cpu, used to determine early stopping point for cpu work
+            probeStepX            = 0.25;
+            probeStepY            = 0.25;
+            probeDefocus          = 0.0;
+            C3                    = 0.0;
+            C5                    = 0.0;
+            probeSemiangle        = 20.0 / 1000;
+            detectorAngleStep     = 1.0 / 1000;
+            probeXtilt            = 0;
+            probeYtilt            = 0;
+            scanWindowXMin        = 0.0;
+            scanWindowXMax        = 0.99999;
+            scanWindowYMin        = 0.0;
+            scanWindowYMax        = 0.99999;
+            scanWindowXMin_r      = 0.0; //realspace alternatives to setting scan window
+            scanWindowXMax_r      = 0.0;
+            scanWindowYMin_r      = 0.0;
+            scanWindowYMax_r      = 0.0;
+            srand(time(0));
+            randomSeed            = rand() % 100000;
+            crop4Damax            = 100.0 /1000;
+            algorithm             = Algorithm::PRISM;
+            includeThermalEffects = true;
+            includeOccupancy      = true;
+            alsoDoCPUWork         = true;
+            save2DOutput          = false;
+            save3DOutput          = true;
+            save4DOutput          = false;
+            crop4DOutput          = false;
+            saveDPC_CoM           = false;
+            saveRealSpaceCoords   = false;
+            savePotentialSlices   = false;
+            userSpecifiedCelldims = false;
+            realSpaceWindow_x     = false;
+            realSpaceWindow_y     = false;
+            integrationAngleMin   = 0;
+            integrationAngleMax   = detectorAngleStep;
+            transferMode          = StreamingMode::Auto;
+            nyquistSampling		  = false;
+        }
+        size_t interpolationFactorY; // PRISM f_y parameter
+        size_t interpolationFactorX; // PRISM f_x parameter
+        std::string filenameAtoms; // filename of txt file containing atoms (x,y,z,Z CSV format -- one atom per line)
+        std::string filenameOutput;// filename of output image
+        std::string outputFolder; // folder of output images
+        T realspacePixelSize[2]; // pixel size
+        T potBound; // bounding integration radius for potential calculation
+        size_t numFP; // number of frozen phonon configurations to compute
+        size_t fpNum; // current frozen phonon number
+        T sliceThickness; // thickness of slice in Z
+        size_t numSlices; //number of slices to itereate through in multislice before giving an output
+        T zStart; //Z coordinate of cell where multislice intermediate output will begin outputting
+        T probeStepX;
+        T probeStepY;
+        std::vector<T> cellDim; // this is z,y,x format
+        size_t tileX, tileY, tileZ; // how many unit cells to repeat in x,y,z
+        size_t batchSizeTargetCPU; // desired number of probes/beams to propagate simultaneously for CPU
+        size_t batchSizeTargetGPU; // desired number of probes/beams to propagate simultaneously for GPU
+        size_t batchSizeCPU; // actual number of probes/beams to propagate simultaneously for CPU
+        size_t batchSizeGPU; // actual number of probes/beams to propagate simultaneously for GPU
+        T earlyCPUStopCount;
+        T E0; // electron energy
+        T alphaBeamMax; // max semi angle for probe
+        T detectorAngleStep;
+        T probeDefocus;
+        T C3;
+        T C5;
+        T probeSemiangle;
+        T probeXtilt;
+        T probeYtilt;
+        T scanWindowXMin;
+        T scanWindowXMax;
+        T scanWindowYMin;
+        T scanWindowYMax;
+        T scanWindowXMin_r;
+        T scanWindowXMax_r;
+        T scanWindowYMin_r;
+        T scanWindowYMax_r;
+        T randomSeed;
+        T crop4Damax;
+        size_t numThreads; // number of CPU threads to use
+        size_t numGPUs; // number of GPUs to use
+        size_t numStreamsPerGPU; // number of CUDA streams to use per GPU
+        Algorithm algorithm;
+        bool includeThermalEffects;
+        bool includeOccupancy;
+        bool alsoDoCPUWork; // what fraction of computation to do on the cpu vs gpu
+        bool save2DOutput;
+        T integrationAngleMin;
+        T integrationAngleMax;
+        bool save3DOutput;
+        bool save4DOutput;
+        bool crop4DOutput;
+        bool saveDPC_CoM;
+        bool saveRealSpaceCoords;
+        bool savePotentialSlices;
+        bool userSpecifiedCelldims;
+        bool realSpaceWindow_x;
+        bool realSpaceWindow_y;
+        bool nyquistSampling;
+        StreamingMode transferMode;
 
-	template <class T>
-	void Metadata<T>::toString(){
-		std::cout << "\nSimulation parameters:" << std::endl;
-		std::cout << "=====================\n" << std::endl;
-		if (algorithm == Prismatic::Algorithm::PRISM){
-			std::cout << "Algorithm: PRISM" << std::endl;
-			std::cout << "interpolationFactorX = " << interpolationFactorX << std::endl;
-			std::cout << "interpolationFactorY = " << interpolationFactorY << std::endl;
-		} else {
-			std::cout << "Algorithm: Multislice" << std::endl;
-		}
+    };
 
-		std::cout << "filenameAtoms = " <<  filenameAtoms     << std::endl;
-		std::cout << "filenameOutput = " << filenameOutput  << std::endl;
-		std::cout << "outputFolder = " << outputFolder  << std::endl;
-		std::cout << "numThreads = " << numThreads << std::endl;
-		std::cout << "realspacePixelSize[0] = " << realspacePixelSize[0]<< std::endl;
-		std::cout << "realspacePixelSize[1] = " << realspacePixelSize[1]<< std::endl;
-		std::cout << "potBound = " << potBound << std::endl;
-		std::cout << "numFP = " << numFP << std::endl;
-		std::cout << "sliceThickness = " << sliceThickness<< std::endl;
-		std::cout << "numSlices = " << numSlices << std::endl;
-		std::cout << "zStart = " << zStart << std::endl;
- 		std::cout << "E0 = " << E0 << std::endl;
-		std::cout << "alphaBeamMax = " << alphaBeamMax << std::endl;
-		std::cout << "numThreads = " << numThreads<< std::endl;
-		std::cout << "batchSizeTargetCPU = " << batchSizeTargetCPU<< std::endl;
-		std::cout << "batchSizeTargetGPU = " << batchSizeTargetGPU<< std::endl;
-		std::cout << "probeStepX = " << probeStepX << std::endl;
-		std::cout << "probeStepY = " << probeStepY << std::endl;
-		std::cout << "cellDim[0] = " << cellDim[0] << std::endl;
-		std::cout << "cellDim[1] = " << cellDim[1] << std::endl;
-		std::cout << "cellDim[2] = " << cellDim[2] << std::endl;
-		std::cout << "tileX = " << tileX << std::endl;
-		std::cout << "tileY = " << tileY << std::endl;
-		std::cout << "tileZ = " << tileZ << std::endl;
-		std::cout << "probeDefocus = " << probeDefocus<< std::endl;
-		std::cout << "C3 = " << C3 << std::endl;
-		std::cout << "C5 = " << C5 << std::endl;
-		std::cout << "probeSemiangle = " << probeSemiangle<< std::endl;
-		std::cout << "detectorAngleStep = " << detectorAngleStep<< std::endl;
-		std::cout << "probeXtilt = " << probeXtilt<< std::endl;
-		std::cout << "probeYtilt = " << probeYtilt<< std::endl;
-		std::cout << "scanWindowXMin = " << scanWindowXMin<< std::endl;
-		std::cout << "scanWindowXMax = " << scanWindowXMax<< std::endl;
-		std::cout << "scanWindowYMin = " << scanWindowYMin<< std::endl;
-		std::cout << "scanWindowYMax = " << scanWindowYMax<< std::endl;
-		std::cout << "scanWindowXMin_r = " << scanWindowXMin_r<< std::endl;
-		std::cout << "scanWindowXMax_r = " << scanWindowXMax_r<< std::endl;
-		std::cout << "scanWindowYMin_r = " << scanWindowYMin_r<< std::endl;
-		std::cout << "scanWindowYMax_r = " << scanWindowYMax_r<< std::endl;
-		std::cout << "integrationAngleMin = " << integrationAngleMin<< std::endl;
-		std::cout << "integrationAngleMax = " << integrationAngleMax<< std::endl;
-		std::cout << "randomSeed = " << randomSeed << std::endl;
+    template <class T>
+    void Metadata<T>::toString(){
+        std::cout << "\nSimulation parameters:" << std::endl;
+        std::cout << "=====================\n" << std::endl;
+        if (algorithm == Prismatic::Algorithm::PRISM){
+            std::cout << "Algorithm: PRISM" << std::endl;
+            std::cout << "interpolationFactorX = " << interpolationFactorX << std::endl;
+            std::cout << "interpolationFactorY = " << interpolationFactorY << std::endl;
+        } else {
+            std::cout << "Algorithm: Multislice" << std::endl;
+        }
 
-		if (includeOccupancy) {
-			std::cout << "includeOccupancy = true" << std::endl;
-		} else {
-			std::cout << "includeOccupancy = false" << std::endl;
-		}
-		if (includeThermalEffects) {
-			std::cout << "includeThermalEffects = true" << std::endl;
-		} else {
-			std::cout << "includeThermalEffects = false" << std::endl;
-		}
-		if (alsoDoCPUWork) {
-			std::cout << "alsoDoCPUWork = true" << std::endl;
-		} else {
-			std::cout << "alsoDoCPUWork = false" << std::endl;
-		}
-		if (save2DOutput) {
-			std::cout << "save2DOutput = true" << std::endl;
-		} else {
-			std::cout << "save2DOutput = false" << std::endl;
-		}
-		if (save3DOutput) {
-			std::cout << "save3DOutput = true" << std::endl;
-		} else {
-			std::cout << "save3DOutput = false" << std::endl;
-		}
-		if (save4DOutput) {
-			std::cout << "save4DOutput = true" << std::endl;
-		} else {
-			std::cout << "save4DOutput = false" << std::endl;
-		}
-		if (saveDPC_CoM) {
-			std::cout << "saveDPC_CoM = true" << std::endl;
-		} else {
-			std::cout << "saveDPC_CoM = false" << std::endl;
-		}
-		if (saveRealSpaceCoords) {
-			std::cout << "saveRealSpaceCoords = true" << std::endl;
-		} else {
-			std::cout << "saveRealSpaceCoords = false" << std::endl;
-		}
-		if (savePotentialSlices) {
-			std::cout << "savePotentialSlices = true" << std::endl;
-		} else {
-			std::cout << "savePotentialSlices= false" << std::endl;
-		}
-		if (nyquistSampling) {
-			std::cout << "nyquistSampling = true" << std::endl;
-		}else{
-			std::cout << "nyquistSampling = false" << std::endl;
-		}
+        std::cout << "filenameAtoms = " <<  filenameAtoms     << std::endl;
+        std::cout << "filenameOutput = " << filenameOutput  << std::endl;
+        std::cout << "outputFolder = " << outputFolder  << std::endl;
+        std::cout << "numThreads = " << numThreads << std::endl;
+        std::cout << "realspacePixelSize[0] = " << realspacePixelSize[0]<< std::endl;
+        std::cout << "realspacePixelSize[1] = " << realspacePixelSize[1]<< std::endl;
+        std::cout << "potBound = " << potBound << std::endl;
+        std::cout << "numFP = " << numFP << std::endl;
+        std::cout << "sliceThickness = " << sliceThickness<< std::endl;
+        std::cout << "numSlices = " << numSlices << std::endl;
+        std::cout << "zStart = " << zStart << std::endl;
+        std::cout << "E0 = " << E0 << std::endl;
+        std::cout << "alphaBeamMax = " << alphaBeamMax << std::endl;
+        std::cout << "numThreads = " << numThreads<< std::endl;
+        std::cout << "batchSizeTargetCPU = " << batchSizeTargetCPU<< std::endl;
+        std::cout << "batchSizeTargetGPU = " << batchSizeTargetGPU<< std::endl;
+        std::cout << "probeStepX = " << probeStepX << std::endl;
+        std::cout << "probeStepY = " << probeStepY << std::endl;
+        std::cout << "cellDim[0] = " << cellDim[0] << std::endl;
+        std::cout << "cellDim[1] = " << cellDim[1] << std::endl;
+        std::cout << "cellDim[2] = " << cellDim[2] << std::endl;
+        std::cout << "tileX = " << tileX << std::endl;
+        std::cout << "tileY = " << tileY << std::endl;
+        std::cout << "tileZ = " << tileZ << std::endl;
+        std::cout << "probeDefocus = " << probeDefocus<< std::endl;
+        std::cout << "C3 = " << C3 << std::endl;
+        std::cout << "C5 = " << C5 << std::endl;
+        std::cout << "probeSemiangle = " << probeSemiangle<< std::endl;
+        std::cout << "detectorAngleStep = " << detectorAngleStep<< std::endl;
+        std::cout << "probeXtilt = " << probeXtilt<< std::endl;
+        std::cout << "probeYtilt = " << probeYtilt<< std::endl;
+        std::cout << "scanWindowXMin = " << scanWindowXMin<< std::endl;
+        std::cout << "scanWindowXMax = " << scanWindowXMax<< std::endl;
+        std::cout << "scanWindowYMin = " << scanWindowYMin<< std::endl;
+        std::cout << "scanWindowYMax = " << scanWindowYMax<< std::endl;
+        std::cout << "scanWindowXMin_r = " << scanWindowXMin_r<< std::endl;
+        std::cout << "scanWindowXMax_r = " << scanWindowXMax_r<< std::endl;
+        std::cout << "scanWindowYMin_r = " << scanWindowYMin_r<< std::endl;
+        std::cout << "scanWindowYMax_r = " << scanWindowYMax_r<< std::endl;
+        std::cout << "integrationAngleMin = " << integrationAngleMin<< std::endl;
+        std::cout << "integrationAngleMax = " << integrationAngleMax<< std::endl;
+        std::cout << "randomSeed = " << randomSeed << std::endl;
+        std::cout << "crop4Damax = " << crop4Damax << std::endl;
+
+        if (includeOccupancy) {
+            std::cout << "includeOccupancy = true" << std::endl;
+        } else {
+            std::cout << "includeOccupancy = false" << std::endl;
+        }
+        if (includeThermalEffects) {
+            std::cout << "includeThermalEffects = true" << std::endl;
+        } else {
+            std::cout << "includeThermalEffects = false" << std::endl;
+        }
+        if (alsoDoCPUWork) {
+            std::cout << "alsoDoCPUWork = true" << std::endl;
+        } else {
+            std::cout << "alsoDoCPUWork = false" << std::endl;
+        }
+        if (save2DOutput) {
+            std::cout << "save2DOutput = true" << std::endl;
+        } else {
+            std::cout << "save2DOutput = false" << std::endl;
+        }
+        if (save3DOutput) {
+            std::cout << "save3DOutput = true" << std::endl;
+        } else {
+            std::cout << "save3DOutput = false" << std::endl;
+        }
+        if (save4DOutput) {
+            std::cout << "save4DOutput = true" << std::endl;
+        } else {
+            std::cout << "save4DOutput = false" << std::endl;
+        }
+        if (crop4DOutput) {
+            std::cout << "crop4DOutput = true" << std::endl;
+        } else {
+            std::cout << "crop4DOutput = false" << std::endl;
+        }
+        if (saveDPC_CoM) {
+            std::cout << "saveDPC_CoM = true" << std::endl;
+        } else {
+            std::cout << "saveDPC_CoM = false" << std::endl;
+        }
+        if (saveRealSpaceCoords) {
+            std::cout << "saveRealSpaceCoords = true" << std::endl;
+        } else {
+            std::cout << "saveRealSpaceCoords = false" << std::endl;
+        }
+        if (savePotentialSlices) {
+            std::cout << "savePotentialSlices = true" << std::endl;
+        } else {
+            std::cout << "savePotentialSlices= false" << std::endl;
+        }
+        if (nyquistSampling) {
+            std::cout << "nyquistSampling = true" << std::endl;
+        }else{
+            std::cout << "nyquistSampling = false" << std::endl;
+        }
 
 
-#ifdef PRISMATIC_ENABLE_GPU
+    #ifdef PRISMATIC_ENABLE_GPU
         std::cout << "numGPUs = " << numGPUs<< std::endl;
         std::cout << "numStreamsPerGPU = " << numStreamsPerGPU<< std::endl;
         std::cout << "alsoDoCPUWork = " << alsoDoCPUWork << std::endl;
         std::cout << "earlyCPUStopCount = " << earlyCPUStopCount  << std::endl;
-		if (transferMode == Prismatic::StreamingMode::Auto){
-			std::cout << "Data Transfer Mode : Auto" << std::endl;
-		} else if (transferMode == Prismatic::StreamingMode::SingleXfer){
-			std::cout << "Data Transfer : Single Transfer" << std::endl;
-		} else {
-			std::cout << "Data Transfer : Streaming" << std::endl;
-		}
-#endif // PRISMATIC_ENABLE_GPU
-	}
+        if (transferMode == Prismatic::StreamingMode::Auto){
+            std::cout << "Data Transfer Mode : Auto" << std::endl;
+        } else if (transferMode == Prismatic::StreamingMode::SingleXfer){
+            std::cout << "Data Transfer : Single Transfer" << std::endl;
+        } else {
+            std::cout << "Data Transfer : Streaming" << std::endl;
+        }
+    #endif // PRISMATIC_ENABLE_GPU
+    }
 
-	template <class T>
-	bool Metadata<T>::operator==(const Metadata<T> other){
-		if(interpolationFactorY != other.interpolationFactorY)return false;
-		if(interpolationFactorX != other.interpolationFactorX)return false;
-		if(filenameAtoms != other.filenameAtoms)return false;
-		if(filenameOutput != other.filenameOutput)return false;
-		if(outputFolder != other.outputFolder)return false;
-		if(realspacePixelSize[0] != realspacePixelSize[0])return false;
-		if(realspacePixelSize[1] != other.realspacePixelSize[1])return false;
-		if(potBound != other.potBound)return false;
-		if(numFP != other.numFP)return false;
-		if(sliceThickness != other.sliceThickness)return false;
-		if(numSlices != other.numSlices)return false;
-		if(zStart != other.zStart)return false;
-		if(cellDim[0] != other.cellDim[0])return false;
-		if(cellDim[1] != other.cellDim[1])return false;
-		if(cellDim[2] != other.cellDim[2])return false;
-		if(tileX != other.tileX)return false;
-		if(tileY != other.tileY)return false;
-		if(tileZ != other.tileZ)return false;
-		if(E0 != other.E0)return false;
-		if(alphaBeamMax != other.alphaBeamMax)return false;
-		if(probeStepX != other.probeStepX)return false;
-		if(probeStepY != other.probeStepY)return false;
-		if(probeSemiangle != other.probeSemiangle)return false;
-		if(C3 != other.C3)return false;
-		if(C5 != other.C5)return false;
-		if(probeDefocus != other.probeDefocus)return false;
-		if(detectorAngleStep != other.detectorAngleStep)return false;
-		if(probeXtilt != other.probeXtilt)return false;
-		if(probeYtilt != other.probeYtilt)return false;
-		if(scanWindowXMin != other.scanWindowXMin)return false;
-		if(scanWindowXMax != other.scanWindowXMax)return false;
-		if(scanWindowYMin != other.scanWindowYMin)return false;
-		if(scanWindowYMax != other.scanWindowYMax)return false;
-		if(scanWindowXMin_r != other.scanWindowXMin_r)return false;
-		if(scanWindowXMax_r != other.scanWindowXMax_r)return false;
-		if(scanWindowYMin_r != other.scanWindowYMin_r)return false;
-		if(scanWindowYMax_r != other.scanWindowYMax_r)return false;
-		if(randomSeed != other.randomSeed)return false;
-		if(includeThermalEffects != other.includeThermalEffects)return false;
-		if(includeOccupancy != other.includeOccupancy)return false;
-		if(alsoDoCPUWork != other.alsoDoCPUWork)return false;
-		if(save2DOutput != other.save2DOutput)return false;
-		if(save3DOutput != other.save3DOutput)return false;
-		if(save4DOutput != other.save4DOutput)return false;
-		if(saveDPC_CoM != other.saveDPC_CoM)return false;
-		if(saveRealSpaceCoords != other.saveRealSpaceCoords)return false;
-		if(savePotentialSlices != other.savePotentialSlices)return false;
-		if(userSpecifiedCelldims != other.userSpecifiedCelldims)return false;
-		if(realSpaceWindow_x != other.realSpaceWindow_x)return false;
-		if(realSpaceWindow_y != other.realSpaceWindow_y)return false;
-		if(nyquistSampling != other.nyquistSampling)return false;
-		return true;
-	}
+    template <class T>
+    bool Metadata<T>::operator==(const Metadata<T> other){
+        if(interpolationFactorY != other.interpolationFactorY)return false;
+        if(interpolationFactorX != other.interpolationFactorX)return false;
+        if(filenameAtoms != other.filenameAtoms)return false;
+        if(filenameOutput != other.filenameOutput)return false;
+        if(outputFolder != other.outputFolder)return false;
+        if(realspacePixelSize[0] != realspacePixelSize[0])return false;
+        if(realspacePixelSize[1] != other.realspacePixelSize[1])return false;
+        if(potBound != other.potBound)return false;
+        if(numFP != other.numFP)return false;
+        if(sliceThickness != other.sliceThickness)return false;
+        if(numSlices != other.numSlices)return false;
+        if(zStart != other.zStart)return false;
+        if(cellDim[0] != other.cellDim[0])return false;
+        if(cellDim[1] != other.cellDim[1])return false;
+        if(cellDim[2] != other.cellDim[2])return false;
+        if(tileX != other.tileX)return false;
+        if(tileY != other.tileY)return false;
+        if(tileZ != other.tileZ)return false;
+        if(E0 != other.E0)return false;
+        if(alphaBeamMax != other.alphaBeamMax)return false;
+        if(probeStepX != other.probeStepX)return false;
+        if(probeStepY != other.probeStepY)return false;
+        if(probeSemiangle != other.probeSemiangle)return false;
+        if(C3 != other.C3)return false;
+        if(C5 != other.C5)return false;
+        if(probeDefocus != other.probeDefocus)return false;
+        if(detectorAngleStep != other.detectorAngleStep)return false;
+        if(probeXtilt != other.probeXtilt)return false;
+        if(probeYtilt != other.probeYtilt)return false;
+        if(scanWindowXMin != other.scanWindowXMin)return false;
+        if(scanWindowXMax != other.scanWindowXMax)return false;
+        if(scanWindowYMin != other.scanWindowYMin)return false;
+        if(scanWindowYMax != other.scanWindowYMax)return false;
+        if(scanWindowXMin_r != other.scanWindowXMin_r)return false;
+        if(scanWindowXMax_r != other.scanWindowXMax_r)return false;
+        if(scanWindowYMin_r != other.scanWindowYMin_r)return false;
+        if(scanWindowYMax_r != other.scanWindowYMax_r)return false;
+        if(randomSeed != other.randomSeed)return false;
+        if(crop4Damax != other.crop4Doutput)return false;
+        if(includeThermalEffects != other.includeThermalEffects)return false;
+        if(includeOccupancy != other.includeOccupancy)return false;
+        if(alsoDoCPUWork != other.alsoDoCPUWork)return false;
+        if(save2DOutput != other.save2DOutput)return false;
+        if(save3DOutput != other.save3DOutput)return false;
+        if(save4DOutput != other.save4DOutput)return false;
+        if(crop4DOutput != other.crop4DOutput)return false;
+        if(saveDPC_CoM != other.saveDPC_CoM)return false;
+        if(saveRealSpaceCoords != other.saveRealSpaceCoords)return false;
+        if(savePotentialSlices != other.savePotentialSlices)return false;
+        if(userSpecifiedCelldims != other.userSpecifiedCelldims)return false;
+        if(realSpaceWindow_x != other.realSpaceWindow_x)return false;
+        if(realSpaceWindow_y != other.realSpaceWindow_y)return false;
+        if(nyquistSampling != other.nyquistSampling)return false;
+        return true;
+    }
 
 }
 #endif //PRISMATIC_META_H

--- a/include/params.h
+++ b/include/params.h
@@ -40,7 +40,7 @@ namespace Prismatic{
 	static std::mutex memLock;
 
 	// for threadsafe HDF5 writing to 4D output
-	static std::mutex HDF5_lock;
+	// static std::mutex HDF5_lock;
 	
     template <class T>
     class Parameters {

--- a/include/params.h
+++ b/include/params.h
@@ -204,6 +204,8 @@ namespace Prismatic{
 		    pixelSize = _pixelSize;
 		    pixelSize[0] /= (T)imageSize[0];
 		    pixelSize[1] /= (T)imageSize[1];
+            std::cout << "Actual pixel size y: " << pixelSize[0] << std::endl;
+            std::cout << "Actual pixel size x: " << pixelSize[1] << std::endl;
 
 			numSlices = meta.numSlices;
 			zStartPlane = (size_t) std::ceil(meta.zStart / meta.sliceThickness);

--- a/include/params.h
+++ b/include/params.h
@@ -208,8 +208,6 @@ namespace Prismatic{
 		    pixelSize = _pixelSize;
 		    pixelSize[0] /= (T)imageSize[0];
 		    pixelSize[1] /= (T)imageSize[1];
-            std::cout << "Actual pixel size y: " << pixelSize[0] << std::endl;
-            std::cout << "Actual pixel size x: " << pixelSize[1] << std::endl;
 
 			numSlices = meta.numSlices;
 			zStartPlane = (size_t) std::ceil(meta.zStart / meta.sliceThickness);

--- a/include/params.h
+++ b/include/params.h
@@ -39,6 +39,9 @@ namespace Prismatic{
 	// for monitoring memory consumption on GPU
 	static std::mutex memLock;
 
+	// for threadsafe HDF5 writing to 4D output
+	static std::mutex HDF5_lock;
+	
     template <class T>
     class Parameters {
 
@@ -106,6 +109,7 @@ namespace Prismatic{
 	    size_t numberBeams;
 		H5::H5File outputFile;
 		size_t fpFlag; //flag to prevent creation of new HDF5 files
+
 #ifdef PRISMATIC_ENABLE_GPU
 		cudaDeviceProp deviceProperties;
 //#ifndef NDEBUG

--- a/include/utility.h
+++ b/include/utility.h
@@ -89,6 +89,69 @@ Array1D<T> fftshift(Array1D<T> arr)
 };
 
 template <class T>
+Array2D<T> circShift(Array2D<T> &arr,const long sj, const long si)
+{
+    Array2D<T> result(arr);
+    for (auto j = 0; j < arr.get_dimj(); ++j)
+    {
+        for (auto i = 0; i < arr.get_dimi(); ++i)
+        {
+            result.at((j + sj) % arr.get_dimj(), (i + si) % arr.get_dimi()) = arr.at(j, i);
+        }
+    }
+    return result;
+};
+
+template <class T>
+Array2D<T> cropOutput(Array2D<T> &img, const Parameters<T> &pars){
+    long qxInd_max = 0;
+    long qyInd_max = 0;
+    PRISMATIC_FLOAT_PRECISION qMax = pars.meta.crop4Damax / pars.lambda;
+
+    for(auto i = 0; i < pars.qx.get_dimi(); i++)
+    {
+        if(pars.qx.at(i) < qMax)
+        {
+            qxInd_max++;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    for(auto j = 0; j < pars.qy.get_dimi(); j++)
+    {
+        if(pars.qy.at(j) < qMax)
+        {
+            qyInd_max++;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    //shift image so that desired region is in top left
+    Array2D<T> shifted = circShift(img,qyInd_max,qxInd_max);
+
+    //construct cropped return image
+    Array2D<T> cropped = zeros_ND<2, PRISMATIC_FLOAT_PRECISION >({{qyInd_max*2, qxInd_max*2}});
+
+    //copy data to return array
+    for(auto j = 0; j < cropped.get_dimj(); j++)
+    {
+        for(auto i = 0; i < cropped.get_dimi(); i++)
+        {
+            cropped.at(j,i) = shifted.at(j,i);
+        }
+    }
+    
+    return cropped;
+}
+
+
+template <class T>
 std::string generateFilename(const Parameters<T> &pars, const size_t currentSlice, const size_t ay, const size_t ax)
 {
 	std::string result = pars.meta.outputFolder + pars.meta.filenameOutput.substr(0, pars.meta.filenameOutput.find_last_of("."));

--- a/include/utility.h
+++ b/include/utility.h
@@ -213,9 +213,9 @@ void writeDatacube3D(H5::DataSet dataset, const float *buffer, const hsize_t *md
 
 void writeDatacube3D(H5::DataSet dataset, const double *buffer, const hsize_t *mdims);
 
-void writeDatacube4D(H5::DataSet dataset, float *buffer, const hsize_t *mdims, const hsize_t *offset, const float numFP);
+void writeDatacube4D(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> pars, float *buffer, const hsize_t *mdims, const hsize_t *offset, const float numFP, const std::string nameString);
 
-void writeDatacube4D(H5::DataSet dataset, double *buffer, const hsize_t *mdims, const hsize_t *offset, const double numFP);
+void writeDatacube4D(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION> pars, double *buffer, const hsize_t *mdims, const hsize_t *offset, const double numFP, const std::string nameString);
 
 void writeStringArray(H5::DataSet dataset,H5std_string * string_array, hsize_t elements);
 

--- a/include/utility.h
+++ b/include/utility.h
@@ -104,8 +104,8 @@ Array2D<T> circShift(Array2D<T> &arr,const long sj, const long si)
 
 template <class T>
 Array2D<T> cropOutput(Array2D<T> &img, const Parameters<T> &pars){
-    long qxInd_max = 0;
-    long qyInd_max = 0;
+    size_t qxInd_max = 0;
+    size_t qyInd_max = 0;
     PRISMATIC_FLOAT_PRECISION qMax = pars.meta.crop4Damax / pars.lambda;
 
     for(auto i = 0; i < pars.qx.get_dimi(); i++)

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -227,20 +227,6 @@ namespace Prismatic{
 		auto psi_ptr = psi.begin();
 		for (auto& j:intOutput) j = pow(abs(*psi_ptr++),2);
 
-		Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{psi.get_dimj()/2, psi.get_dimi()/2}});
-
-		{
-			long offset_x = psi.get_dimi() / 4;
-			long offset_y = psi.get_dimj() / 4;
-			long ndimy = (long) psi.get_dimj();
-			long ndimx = (long) psi.get_dimi();
-			for (long y = 0; y < psi.get_dimj() / 2; ++y) {
-				for (long x = 0; x < psi.get_dimi() / 2; ++x) {
-					intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
-					                            ((x - offset_x) % ndimx + ndimx) % ndimx);
-				}
-			}
-		}
 
 		if (pars.meta.saveDPC_CoM){
 			//calculate center of mass; qxa, qya are the fourier coordinates, should have 0 components at boundaries
@@ -270,23 +256,51 @@ namespace Prismatic{
 
 		//save 4D output if applicable
 		if (pars.meta.save4DOutput) {
-			unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
-			//std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
-			std::stringstream nameString;
-			nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
 
-			H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-			H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+            
+            Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small;
+            hsize_t mdims[4];
+            mdims[0] = mdims[1] = {1};
+            
+            if(pars.meta.crop4DOutput)
+            {
+                intOutput_small = cropOutput(intOutput,pars);
+            }
+            else
+            {
+                intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{psi.get_dimj()/2, psi.get_dimi()/2}});
+                {
+                    long offset_x = psi.get_dimi() / 4;
+                    long offset_y = psi.get_dimj() / 4;
+                    long ndimy = (long) psi.get_dimj();
+                    long ndimx = (long) psi.get_dimi();
+                    for (long y = 0; y < psi.get_dimj() / 2; ++y) {
+                        for (long x = 0; x < psi.get_dimi() / 2; ++x) {
+                            intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
+                                                        ((x - offset_x) % ndimx + ndimx) % ndimx);
+                        }
+                    }
+                }
+            }
 
-			hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
-			hsize_t mdims[4] = {1,1,pars.psiProbeInit.get_dimj()/2,pars.psiProbeInit.get_dimi()/2};
-			PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
-			writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+            mdims[2] = {intOutput_small.get_dimi()};
+            mdims[3] = {intOutput_small.get_dimj()};
+            unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
+            //std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
+            std::stringstream nameString;
+            nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
 
-			CBED_data.close();
-			dataGroup.close();
-			HDF5_gatekeeper.unlock();
-			//intOutput_small.toMRC_f(section4DFilename.c_str());
+            H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+            H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+
+            hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
+            PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
+            writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+
+            CBED_data.close();
+            dataGroup.close();
+            HDF5_gatekeeper.unlock();
+            //intOutput_small.toMRC_f(section4DFilename.c_str());
 		}
 	}
 	void formatOutput_CPU_integrate_batch(Parameters<PRISMATIC_FLOAT_PRECISION>& pars,
@@ -303,23 +317,6 @@ namespace Prismatic{
 					{{pars.psiProbeInit.get_dimj(), pars.psiProbeInit.get_dimi()}});
 			auto psi_ptr = &psi_stack[probe_idx*pars.psiProbeInit.size()];
 			for (auto &j:intOutput) j = pow(abs(*psi_ptr++), 2);
-
-			Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{pars.psiProbeInit.get_dimj()/2, pars.psiProbeInit.get_dimi()/2}});
-
-			{
-				long offset_x = pars.psiProbeInit.get_dimi() / 4;
-				long offset_y = pars.psiProbeInit.get_dimj() / 4;
-				long ndimy = (long) pars.psiProbeInit.get_dimj();
-				long ndimx = (long) pars.psiProbeInit.get_dimi();
-
-				for (long y = 0; y < pars.psiProbeInit.get_dimj() / 2; ++y) {
-					for (long x = 0; x < pars.psiProbeInit.get_dimi() / 2; ++x) {
-						intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
-													((x - offset_x) % ndimx + ndimx) % ndimx);
-					}
-				}
-			}
-
 
 			if (pars.meta.saveDPC_CoM){
 				//calculate center of mass; qxa, qya are the fourier coordinates, should have 0 components at boundaries
@@ -348,26 +345,55 @@ namespace Prismatic{
 				++idx;
 			};
 
-			//save 4D output if applicable
-			if (pars.meta.save4DOutput) {
-				//std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
-				unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
-				std::stringstream nameString;
-				nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
+            //save 4D output if applicable
+            if (pars.meta.save4DOutput) {
 
-				H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-				H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+                Array2D<PRISMATIC_FLOAT_PRECISION> intOutput_small;
 
-				hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
-				hsize_t mdims[4] = {1,1,pars.psiProbeInit.get_dimj()/2,pars.psiProbeInit.get_dimi()/2};
-				PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
-				writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+                hsize_t mdims[4];
+                mdims[0] = mdims[1] = {1};
+            
+                if(pars.meta.crop4DOutput)
+                {
+                    intOutput_small = cropOutput(intOutput,pars);
+                }
+                else
+                {
+                    intOutput_small = zeros_ND<2, PRISMATIC_FLOAT_PRECISION>({{pars.psiProbeInit.get_dimj()/2, pars.psiProbeInit.get_dimi()/2}});
+                    {
+                        long offset_x = pars.psiProbeInit.get_dimi() / 4;
+                        long offset_y = pars.psiProbeInit.get_dimj() / 4;
+                        long ndimy = (long) pars.psiProbeInit.get_dimj();
+                        long ndimx = (long) pars.psiProbeInit.get_dimi();
+                        for (long y = 0; y < pars.psiProbeInit.get_dimj() / 2; ++y) {
+                            for (long x = 0; x < pars.psiProbeInit.get_dimi() / 2; ++x) {
+                                intOutput_small.at(y, x) = intOutput.at(((y - offset_y) % ndimy + ndimy) % ndimy,
+                                                            ((x - offset_x) % ndimx + ndimx) % ndimx);
+                            }
+                        }
+                    }
+                }
 
-				CBED_data.close();
-				dataGroup.close();
-				HDF5_gatekeeper.unlock();
-				//intOutput_small.toMRC_f(section4DFilename.c_str());
-			}
+                
+                mdims[2] = {intOutput_small.get_dimi()};
+                mdims[3] = {intOutput_small.get_dimj()};
+                //std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
+                unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
+                std::stringstream nameString;
+                nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
+
+                H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+                H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+
+                hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
+                PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
+                writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+
+                CBED_data.close();
+                dataGroup.close();
+                HDF5_gatekeeper.unlock();
+                //intOutput_small.toMRC_f(section4DFilename.c_str());
+            }
 
 			++Nstart;
 			++probe_idx;

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -285,21 +285,21 @@ namespace Prismatic{
 
             mdims[2] = {intOutput_small.get_dimi()};
             mdims[3] = {intOutput_small.get_dimj()};
-            unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
+            // unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
             //std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
             std::stringstream nameString;
             nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
 
-            H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-            H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+            // H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+            // H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
 
             hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
             PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
-            writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+            writeDatacube4D(pars,&intOutput_small[0],mdims,offset,numFP,nameString.str());
 
-            CBED_data.close();
-            dataGroup.close();
-            HDF5_gatekeeper.unlock();
+            // CBED_data.close();
+            // dataGroup.close();
+            // HDF5_gatekeeper.unlock();
             //intOutput_small.toMRC_f(section4DFilename.c_str());
 		}
 	}
@@ -378,20 +378,20 @@ namespace Prismatic{
                 mdims[2] = {intOutput_small.get_dimi()};
                 mdims[3] = {intOutput_small.get_dimj()};
                 //std::string section4DFilename = generateFilename(pars, currentSlice, ay, ax);
-                unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
+                // unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
                 std::stringstream nameString;
                 nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(currentSlice);
 
-                H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-                H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+                // H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+                // H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
 
                 hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
                 PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
-                writeDatacube4D(CBED_data, &intOutput_small[0],mdims,offset,numFP);
+                writeDatacube4D(pars, &intOutput_small[0],mdims,offset,numFP,nameString.str());
 
-                CBED_data.close();
-                dataGroup.close();
-                HDF5_gatekeeper.unlock();
+                // CBED_data.close();
+                // dataGroup.close();
+                // HDF5_gatekeeper.unlock();
                 //intOutput_small.toMRC_f(section4DFilename.c_str());
             }
 

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -31,7 +31,7 @@ namespace Prismatic{
 	static const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
 	static const std::complex<PRISMATIC_FLOAT_PRECISION> i(0, 1);
 	mutex fftw_plan_lock; // for synchronizing access to shared FFTW resources
-	mutex HDF5_lock;
+	// mutex HDF5_lock;
 
 	void setupCoordinates_multislice(Parameters<PRISMATIC_FLOAT_PRECISION>& pars){
 

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -177,6 +177,10 @@ Parameters<PRISMATIC_FLOAT_PRECISION> Multislice_entry(Metadata<PRISMATIC_FLOAT_
 		Array3D<PRISMATIC_FLOAT_PRECISION> DPC_slice;
 		DPC_slice = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.DPC_CoM.get_dimj(), prismatic_pars.DPC_CoM.get_dimk(), 2}});
 		hsize_t mdims[3] = {prismatic_pars.xp.size(), prismatic_pars.yp.size(), 2};
+        std::cout << "XP size: " << prismatic_pars.xp.size() << std::endl;
+        std::cout << "YP size: " << prismatic_pars.yp.size() << std::endl;
+        std::cout << "DPC_x size: " << prismatic_pars.DPC_CoM.get_dimj() << std::endl;
+        std::cout << "DPC_y size: " << prismatic_pars.DPC_CoM.get_dimk() << std::endl;
 
 		for (auto j = 0; j < prismatic_pars.output.get_diml(); j++)
 		{
@@ -199,7 +203,7 @@ Parameters<PRISMATIC_FLOAT_PRECISION> Multislice_entry(Metadata<PRISMATIC_FLOAT_
 				}
 			}
 
-			writeRealSlice(DPC_data, &DPC_slice[0], mdims);
+			writeDatacube3D(DPC_data, &DPC_slice[0], mdims);
 			DPC_data.close();
 			dataGroup.close();
 		}

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -177,10 +177,6 @@ Parameters<PRISMATIC_FLOAT_PRECISION> Multislice_entry(Metadata<PRISMATIC_FLOAT_
 		Array3D<PRISMATIC_FLOAT_PRECISION> DPC_slice;
 		DPC_slice = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.DPC_CoM.get_dimj(), prismatic_pars.DPC_CoM.get_dimk(), 2}});
 		hsize_t mdims[3] = {prismatic_pars.xp.size(), prismatic_pars.yp.size(), 2};
-        std::cout << "XP size: " << prismatic_pars.xp.size() << std::endl;
-        std::cout << "YP size: " << prismatic_pars.yp.size() << std::endl;
-        std::cout << "DPC_x size: " << prismatic_pars.DPC_CoM.get_dimj() << std::endl;
-        std::cout << "DPC_y size: " << prismatic_pars.DPC_CoM.get_dimk() << std::endl;
 
 		for (auto j = 0; j < prismatic_pars.output.get_diml(); j++)
 		{

--- a/src/PRISM02_calcSMatrix.cu
+++ b/src/PRISM02_calcSMatrix.cu
@@ -954,14 +954,21 @@ namespace Prismatic {
 		// setup some needed arrays
 		const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
 		const std::complex<PRISMATIC_FLOAT_PRECISION> i(0, 1);
+		std::cout << "Nbytes in float: " << sizeof(PRISMATIC_FLOAT_PRECISION) << std::endl;
+		std::cout << "Nbytes in complex float: " << sizeof(complex<PRISMATIC_FLOAT_PRECISION>) << std::endl;
+		std::cout << "Number of beams: " << pars.numberBeams << std::endl;
+		std::cout << "Image size (qy/2,qx/2): " << pars.imageSize[0]/2 << " " << pars.imageSize[1]/2 << std::endl;	
 		pars.Scompact = zeros_ND<3, complex<PRISMATIC_FLOAT_PRECISION> >(
 				{{pars.numberBeams, pars.imageSize[0] / 2, pars.imageSize[1] / 2}});
+		std::cout << "Scompact created. " << std::endl;
+		std::cout << "Transmission array size: " << pars.pot.get_dimk() << ", " << pars.pot.get_dimj() << ", " << pars.pot.get_dimi() << std::endl;
 		pars.transmission = zeros_ND<3, complex<PRISMATIC_FLOAT_PRECISION> >(
 				{{pars.pot.get_dimk(), pars.pot.get_dimj(), pars.pot.get_dimi()}});
 		{
 			auto p = pars.pot.begin();
 			for (auto &j:pars.transmission)j = exp(i * pars.sigma * (*p++));
 		}
+		std::cout << "Transmission array created." << std::endl;
 	}
 
 	void fill_Scompact_GPU_singlexfer(Parameters <PRISMATIC_FLOAT_PRECISION> &pars) {
@@ -975,22 +982,27 @@ namespace Prismatic {
 
 		// determine the batch size to use
         pars.meta.batchSizeGPU = min(pars.meta.batchSizeTargetGPU, max((size_t)1, pars.numberBeams / max((size_t)1,(pars.meta.numStreamsPerGPU*pars.meta.numGPUs))));
-
+		std::cout << "setup arrays." << std::endl;
 		// setup some arrays
 		setupArrays2(pars);
 
+		std::cout << "create streams and plans." << std::endl;
 		// create CUDA streams
 		createStreamsAndPlans2(pars, cuda_pars);
 
+		std::cout <<"Allocate pinned host memory." << std::endl;
 		// create page-locked (pinned) host memory buffers
 		allocatePinnedHostMemory_singlexfer2(pars, cuda_pars);
 
+		std::cout << "Pinned memory copy." << std::endl;
 		// copy to pinned memory
 		copyToPinnedMemory_singlexfer2(pars, cuda_pars);
 
+		std::cout << "Device memory allocation." << std::endl;
 		// allocate memory on the GPUs
 		allocateDeviceMemory_singlexfer2(pars, cuda_pars);
 
+		std::cout << "Device memory copy." << std::endl;
 		// copy to GPUs
 		copyToDeviceMemory_singlexfer2(pars, cuda_pars);
 
@@ -1013,22 +1025,27 @@ namespace Prismatic {
 
 		// determine the batch size to use
 		pars.meta.batchSizeGPU = min(pars.meta.batchSizeTargetGPU, max((size_t)1, pars.numberBeams / max((size_t)1,(pars.meta.numStreamsPerGPU*pars.meta.numGPUs))));
-
+		std::cout << "Setup arrays 2." << std::endl;
 		// setup some arrays
 		setupArrays2(pars);
-
+		
+		std::cout << "Stream and plans. " << std::endl;
 		// create CUDA streams and cuFFT plans
 		createStreamsAndPlans2(pars, cuda_pars);
 
+		std::cout << "Allocating pinned memory." << std::endl;
 		// create page-locked (pinned) host memory buffers
 		allocatePinnedHostMemory_streaming2(pars, cuda_pars);
 
+		std::cout << "Pinned memory copy. " << std::endl;
 		// copy to pinned memory
 		copyToPinnedMemory_streaming2(pars, cuda_pars);
 
+		std::cout << "GPU memory allocation. " << std::endl;
 		// allocate memory on the GPUs
 		allocateDeviceMemory_streaming2(pars, cuda_pars);
 
+		std::cout << "GPU memmory copy. " << std::endl;
 		// copy to GPUs
 		copyToDeviceMemory_streaming2(pars, cuda_pars);
 

--- a/src/PRISM02_calcSMatrix.cu
+++ b/src/PRISM02_calcSMatrix.cu
@@ -954,21 +954,14 @@ namespace Prismatic {
 		// setup some needed arrays
 		const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
 		const std::complex<PRISMATIC_FLOAT_PRECISION> i(0, 1);
-		std::cout << "Nbytes in float: " << sizeof(PRISMATIC_FLOAT_PRECISION) << std::endl;
-		std::cout << "Nbytes in complex float: " << sizeof(complex<PRISMATIC_FLOAT_PRECISION>) << std::endl;
-		std::cout << "Number of beams: " << pars.numberBeams << std::endl;
-		std::cout << "Image size (qy/2,qx/2): " << pars.imageSize[0]/2 << " " << pars.imageSize[1]/2 << std::endl;	
 		pars.Scompact = zeros_ND<3, complex<PRISMATIC_FLOAT_PRECISION> >(
 				{{pars.numberBeams, pars.imageSize[0] / 2, pars.imageSize[1] / 2}});
-		std::cout << "Scompact created. " << std::endl;
-		std::cout << "Transmission array size: " << pars.pot.get_dimk() << ", " << pars.pot.get_dimj() << ", " << pars.pot.get_dimi() << std::endl;
 		pars.transmission = zeros_ND<3, complex<PRISMATIC_FLOAT_PRECISION> >(
 				{{pars.pot.get_dimk(), pars.pot.get_dimj(), pars.pot.get_dimi()}});
 		{
 			auto p = pars.pot.begin();
 			for (auto &j:pars.transmission)j = exp(i * pars.sigma * (*p++));
 		}
-		std::cout << "Transmission array created." << std::endl;
 	}
 
 	void fill_Scompact_GPU_singlexfer(Parameters <PRISMATIC_FLOAT_PRECISION> &pars) {
@@ -982,27 +975,21 @@ namespace Prismatic {
 
 		// determine the batch size to use
         pars.meta.batchSizeGPU = min(pars.meta.batchSizeTargetGPU, max((size_t)1, pars.numberBeams / max((size_t)1,(pars.meta.numStreamsPerGPU*pars.meta.numGPUs))));
-		std::cout << "setup arrays." << std::endl;
 		// setup some arrays
 		setupArrays2(pars);
 
-		std::cout << "create streams and plans." << std::endl;
 		// create CUDA streams
 		createStreamsAndPlans2(pars, cuda_pars);
 
-		std::cout <<"Allocate pinned host memory." << std::endl;
 		// create page-locked (pinned) host memory buffers
 		allocatePinnedHostMemory_singlexfer2(pars, cuda_pars);
 
-		std::cout << "Pinned memory copy." << std::endl;
 		// copy to pinned memory
 		copyToPinnedMemory_singlexfer2(pars, cuda_pars);
 
-		std::cout << "Device memory allocation." << std::endl;
 		// allocate memory on the GPUs
 		allocateDeviceMemory_singlexfer2(pars, cuda_pars);
 
-		std::cout << "Device memory copy." << std::endl;
 		// copy to GPUs
 		copyToDeviceMemory_singlexfer2(pars, cuda_pars);
 
@@ -1025,27 +1012,21 @@ namespace Prismatic {
 
 		// determine the batch size to use
 		pars.meta.batchSizeGPU = min(pars.meta.batchSizeTargetGPU, max((size_t)1, pars.numberBeams / max((size_t)1,(pars.meta.numStreamsPerGPU*pars.meta.numGPUs))));
-		std::cout << "Setup arrays 2." << std::endl;
 		// setup some arrays
 		setupArrays2(pars);
 		
-		std::cout << "Stream and plans. " << std::endl;
 		// create CUDA streams and cuFFT plans
 		createStreamsAndPlans2(pars, cuda_pars);
 
-		std::cout << "Allocating pinned memory." << std::endl;
 		// create page-locked (pinned) host memory buffers
 		allocatePinnedHostMemory_streaming2(pars, cuda_pars);
 
-		std::cout << "Pinned memory copy. " << std::endl;
 		// copy to pinned memory
 		copyToPinnedMemory_streaming2(pars, cuda_pars);
 
-		std::cout << "GPU memory allocation. " << std::endl;
 		// allocate memory on the GPUs
 		allocateDeviceMemory_streaming2(pars, cuda_pars);
 
-		std::cout << "GPU memmory copy. " << std::endl;
 		// copy to GPUs
 		copyToDeviceMemory_streaming2(pars, cuda_pars);
 

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -433,12 +433,12 @@ void buildSignal_CPU(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 	if (pars.meta.save4DOutput)
 	{
 		//std::string section4DFilename = generateFilename(pars, 0, ay, ax);
-		unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
+		// unique_lock<mutex> HDF5_gatekeeper(HDF5_lock);
 		std::stringstream nameString;
 		nameString << "4DSTEM_simulation/data/datacubes/CBED_array_depth" << getDigitString(0);
 
-		H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-		H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+		// H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+		// H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
 
 		hsize_t offset[4] = {ax, ay, 0, 0}; //order by ax, ay so that aligns with py4DSTEM
 
@@ -448,18 +448,18 @@ void buildSignal_CPU(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
         {
             Array2D<PRISMATIC_FLOAT_PRECISION> croppedOutput = cropOutput(intOutput,pars);
             hsize_t mdims[4] = {1, 1, croppedOutput.get_dimi(), croppedOutput.get_dimj()};
-            writeDatacube4D(CBED_data, &croppedOutput[0], mdims, offset, numFP);
+            writeDatacube4D(pars, &croppedOutput[0], mdims, offset, numFP, nameString.str());
         }
         else
         {
             hsize_t mdims[4] = {1, 1, intOutput.get_dimi(), intOutput.get_dimj()};
             intOutput = fftshift2(intOutput);
-            writeDatacube4D(CBED_data, &intOutput[0], mdims, offset, numFP);
+            writeDatacube4D(pars, &intOutput[0], mdims, offset, numFP,nameString.str());
         }
 
-		CBED_data.close();
-		dataGroup.close();
-		HDF5_gatekeeper.unlock();
+		// CBED_data.close();
+		// dataGroup.close();
+		// HDF5_gatekeeper.unlock();
 		//intOutput.toMRC_f(section4DFilename.c_str());
 	}
 }

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -441,11 +441,21 @@ void buildSignal_CPU(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 		H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
 
 		hsize_t offset[4] = {ax, ay, 0, 0}; //order by ax, ay so that aligns with py4DSTEM
-		hsize_t mdims[4] = {1, 1, intOutput.get_dimi(), intOutput.get_dimj()};
 
-		intOutput = fftshift2(intOutput);
 		PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
-		writeDatacube4D(CBED_data, &intOutput[0], mdims, offset, numFP);
+
+        if(pars.meta.crop4DOutput)
+        {
+            Array2D<PRISMATIC_FLOAT_PRECISION> croppedOutput = cropOutput(intOutput,pars);
+            hsize_t mdims[4] = {1, 1, croppedOutput.get_dimi(), croppedOutput.get_dimj()};
+            writeDatacube4D(CBED_data, &croppedOutput[0], mdims, offset, numFP);
+        }
+        else
+        {
+            hsize_t mdims[4] = {1, 1, intOutput.get_dimi(), intOutput.get_dimj()};
+            intOutput = fftshift2(intOutput);
+            writeDatacube4D(CBED_data, &intOutput[0], mdims, offset, numFP);
+        }
 
 		CBED_data.close();
 		dataGroup.close();

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -33,7 +33,7 @@
 namespace Prismatic
 {
 extern std::mutex fftw_plan_lock; // for synchronizing access to shared FFTW resources
-extern std::mutex HDF5_lock;
+// extern std::mutex HDF5_lock;
 using namespace std;
 const static std::complex<PRISMATIC_FLOAT_PRECISION> i(0, 1);
 // this might seem a strange way to get pi, but it's slightly more future proof

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -1469,7 +1469,7 @@ static std::map<std::string, parseFunction> parser{
     {"--save-4D-output", parse_4D}, {"-4D", parse_4D},
     {"--4D-crop", parse_4DC}, {"-4DC", parse_4DC},
     {"--4D-amax", parse_4DA}, {"-4DA", parse_4DA},
-    {"--save-DPC_CoM", parse_dpc}, {"-DPC", parse_dpc},
+    {"--save-DPC-CoM", parse_dpc}, {"-DPC", parse_dpc},
     {"--save-real-space-coords", parse_rsc}, {"-rsc", parse_rsc},
     {"--save-potential-slices", parse_ps}, {"-ps", parse_ps},
     {"--nyquist-sampling", parse_nqs}, {"-nqs", parse_nqs}};

--- a/src/utility.cu
+++ b/src/utility.cu
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <mutex>
 
-std::mutex HDF5_lock;
+// std::mutex HDF5_lock;
 
 #define PI 3.14159265359
 // define some constants
@@ -500,7 +500,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 								   stream));
 								   
 		//Need to scale the output by the square of the PRISM interpolation factor 
-		std::unique_lock<std::mutex> HDF5_gatekeeper(HDF5_lock);
+		std::unique_lock<std::mutex> HDF5_gatekeeper(Prismatic::HDF5_lock);
 
 		currentImage *= pars.scale;
 		std::stringstream nameString;

--- a/src/utility.cu
+++ b/src/utility.cu
@@ -500,14 +500,14 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
 								   stream));
 								   
 		//Need to scale the output by the square of the PRISM interpolation factor 
-		std::unique_lock<std::mutex> HDF5_gatekeeper(Prismatic::HDF5_lock);
+		// std::unique_lock<std::mutex> HDF5_gatekeeper(Prismatic::HDF5_lock);
 
 		currentImage *= pars.scale;
 		std::stringstream nameString;
 		nameString << "/4DSTEM_simulation/data/datacubes/CBED_array_depth" << Prismatic::getDigitString(currentSlice);
 		
-		H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
-		H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
+		// H5::Group dataGroup = pars.outputFile.openGroup(nameString.str());
+		// H5::DataSet CBED_data = dataGroup.openDataSet("datacube");
 
 		hsize_t offset[4] = {ax,ay,0,0}; //order by ax, ay so that aligns with py4DSTEM
         PRISMATIC_FLOAT_PRECISION numFP = pars.meta.numFP;
@@ -516,7 +516,7 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
         {
             Prismatic::Array2D<PRISMATIC_FLOAT_PRECISION> finalImage = cropOutput(currentImage,pars);
             hsize_t mdims[4] = {1,1,finalImage.get_dimi(),finalImage.get_dimj()};
-            Prismatic::writeDatacube4D(CBED_data, &finalImage[0],mdims,offset,numFP);
+            Prismatic::writeDatacube4D(pars, &finalImage[0],mdims,offset,numFP,nameString.str());
         }
         else
         {
@@ -539,18 +539,18 @@ void formatOutput_GPU_integrate(Prismatic::Parameters<PRISMATIC_FLOAT_PRECISION>
                     
                     //finalImage = fftshift2(finalImage);
                     hsize_t mdims[4] = {1,1,pars.psiProbeInit.get_dimi()/2,pars.psiProbeInit.get_dimj()/2};
-                    Prismatic::writeDatacube4D(CBED_data, &finalImage[0],mdims,offset,numFP);
+                    Prismatic::writeDatacube4D(pars, &finalImage[0],mdims,offset,numFP,nameString.str());
                     //finalImage.toMRC_f(section4DFilename.c_str());
                 }else{                     
                     currentImage = fftshift2(currentImage);
                     hsize_t mdims[4] = {1,1,pars.psiProbeInit.get_dimi(),pars.psiProbeInit.get_dimj()};
-                    Prismatic::writeDatacube4D(CBED_data, &currentImage[0],mdims,offset,numFP);
+                    Prismatic::writeDatacube4D(pars, &currentImage[0],mdims,offset,numFP,nameString.str());
                     //currentImage.toMRC_f(section4DFilename.c_str());
                 }
         }
-        CBED_data.close();
-        dataGroup.close();
-        HDF5_gatekeeper.unlock();
+        // CBED_data.close();
+        // dataGroup.close();
+        // HDF5_gatekeeper.unlock();
     }
 //		cudaSetDeviceFlags(cudaDeviceBlockingSync);
 


### PR DESCRIPTION
This commit is intended to version up Prismatic to v1.2.1. It fixes some serious bugs with saving rectangular 4D images and with consistently reading/writing the different FP outputs. It also implements cropping functionality into the CLI version, such that 4D output images can be cropped to an arbitrary distance in q-space.