### PR TITLE
Fix occupancy pyprismatic

### DIFF
--- a/pyprismatic/core.cpp
+++ b/pyprismatic/core.cpp
@@ -30,8 +30,8 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	int randomSeed;
 	int numFP, batchSizeTargetCPU, batchSizeTargetGPU,
 		tileX, tileY, tileZ,
-		numGPUs, numStreamsPerGPU, numThreads, includeThermalEffects, alsoDoCPUWork, save2DOutput,
-		save3DOutput, save4DOutput, saveDPC_CoM, savePotentialSlices, nyquistSampling, numSlices;
+		numGPUs, numStreamsPerGPU, numThreads, includeThermalEffects, includeOccupancy, alsoDoCPUWork,
+		save2DOutput, save3DOutput, save4DOutput, saveDPC_CoM, savePotentialSlices, nyquistSampling, numSlices;
 	char *filenameAtoms, *filenameOutput, *algorithm, *transferMode;
 	double realspacePixelSizeX, realspacePixelSizeY, potBound,
 		sliceThickness, probeStepX, probeStepY,
@@ -47,7 +47,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 #endif //PRISMATIC_ENABLE_GPU
 
 	if (!PyArg_ParseTuple(
-			args, "iissdddiddddiiiddiiiiiddddddddddddddispppppddsiiiiddddd",
+			args, "iissdddiddddiiiddiiiiiddddddddddddddisppppppddsiiiiddddd",
 			&interpolationFactorX,
 			&interpolationFactorY,
 			&filenameAtoms,
@@ -87,6 +87,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 			&randomSeed,
 			&algorithm,
 			&includeThermalEffects,
+			&includeOccupancy,
 			&alsoDoCPUWork,
 			&save2DOutput,
 			&save3DOutput,
@@ -158,6 +159,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 		meta.algorithm = Prismatic::Algorithm::PRISM;
 	}
 	meta.includeThermalEffects = includeThermalEffects;
+	meta.includeOccupancy = includeOccupancy;
 	meta.alsoDoCPUWork = alsoDoCPUWork;
 	meta.save2DOutput = save2DOutput;
 	meta.save3DOutput = save3DOutput;
@@ -186,7 +188,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	int scratch = Prismatic::writeParamFile(meta,"scratch_param.txt");
 
 	Prismatic::Metadata<PRISMATIC_FLOAT_PRECISION> tmp_meta;
-	if(Prismatic::parseParamFile(tmp_meta,"scratch_param.txt")) 
+	if(Prismatic::parseParamFile(tmp_meta,"scratch_param.txt"))
 	{
 		Prismatic::go(meta);
 	}else{

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -11,6 +11,8 @@
 #    Implementation of Image Simulation Algorithms for Scanning
 #    Transmission Electron Microscopy. arXiv:1706.08563 (2017)
 
+import os
+import time
 from typing import List, Any
 import pyprismatic.core
 
@@ -327,11 +329,30 @@ class Metadata:
         outf.close()
 
     def toString(self):
+        """
+        Display the simulation parameters.
+        """
         for field in Metadata.fields:
             print("{} = {}".format(field, getattr(self, field)))
 
-    def go(self):
+    def go(self, display_run_time=True, save_run_time=True):
+        """Run the simulation. To display and/or export the simulation run
+        time set the corresponding arguments ``display_run_time`` and
+        ``save_run_time`` to ``True`` or ``False`` (default is True).
+        """
         self.algorithm: str = self.algorithm.lower()
         self.transferMode: str = self.transferMode.lower()
         l: List[Any] = [getattr(self, field) for field in Metadata.fields]
+        start = time.time()
         pyprismatic.core.go(*l)
+        end = time.time()
+
+        # Display and save run time when requested
+        formatted_time = time.strftime("%H:%M:%S", time.gmtime(end-start))
+        total_time = f"The simulation time of {self.filenameOutput} was: {formatted_time} ({end-start:6g} s)"
+        if display_run_time:
+            print(total_time)
+        if save_run_time:
+            filename = f"{os.path.splitext(self.filenameOutput)[0]}-timing.txt"
+            with open(filename, 'w') as f:
+                f.write(total_time)

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -36,8 +36,8 @@ class Metadata:
     "tileX" : number of unit cells to tile in X direction
     "tileY" : number of unit cells to tile in Y direction
     "tileZ" : number of unit cells to tile in Z direction
-    "E0" : electron beam energy (in eV)
-    "alphaBeamMax" : the maximum probe angle to consider (in rad)
+    "E0" : electron beam energy (in keV)
+    "alphaBeamMax" : the maximum probe angle to consider (in mrad)
     "numGPUs" : number of GPUs to use. A runtime check is performed to check how many are actually available, and the minimum of these two numbers is used.
     "numStreamsPerGPU" : number of CUDA streams to use per GPU
     "numThreads" : number of CPU worker threads to use
@@ -49,10 +49,10 @@ class Metadata:
     "probeDefocus" : probe defocus (in Angstroms)
     "C3" : microscope C3 (in Angstroms)
     "C5" : microscope C5 (in Angstroms)
-    "probeSemiangle" : probe convergence semi-angle (in rad)
-    "detectorAngleStep" : angular step size for detector integration bins (in rad)
-    "probeXtilt" : (in Angstroms)
-    "probeYtilt" : (in Angstroms)
+    "probeSemiangle" : probe convergence semi-angle (in mrad)
+    "detectorAngleStep" : angular step size for detector integration bins (in mrad)
+    "probeXtilt" : (in mrad)
+    "probeYtilt" : (in mrad)
     "scanWindowXMin" : lower X size of the window to scan the probe (in fractional coordinates)
     "scanWindowXMax" : upper X size of the window to scan the probe (in fractional coordinates)
     "scanWindowYMin" : lower Y size of the window to scan the probe (in fractional coordinates)
@@ -74,8 +74,8 @@ class Metadata:
     "crop4DOutput" : true/false Crop the 4D output smaller than the anti-aliasing boundary (default: False)
     "crop4Damax" : float If crop4D, the maximum angle to which the output is cropped (in mrad) (default: 100)
     "nyquistSampling": set number of probe positions at Nyquist sampling limit
-    "integrationAngleMin" : (in rad)
-    "integrationAngleMax" : (in rad)
+    "integrationAngleMin" : (in mrad)
+    "integrationAngleMax" : (in mrad)
     "transferMode" : memory model to use, either "streaming", "singlexfer", or "auto"
     """
 
@@ -165,7 +165,8 @@ class Metadata:
         "potBound",
         "sliceThickness",
         "E0",
-        "alphaBeamMax" "earlyCPUStopCount",
+        "alphaBeamMax",
+        "earlyCPUStopCount",
         "probeStepX",
         "probeStepY",
         "probeDefocus",
@@ -217,8 +218,8 @@ class Metadata:
         self.tileX = 3
         self.tileY = 3
         self.tileZ = 1
-        self.E0 = 80e3
-        self.alphaBeamMax = 0.024
+        self.E0 = 80
+        self.alphaBeamMax = 24
         self.numGPUs = 4
         self.numStreamsPerGPU = 3
         self.numThreads = 12
@@ -232,8 +233,8 @@ class Metadata:
         self.probeDefocus = 0.0
         self.C3 = 0.0
         self.C5 = 0.0
-        self.probeSemiangle = 0.02
-        self.detectorAngleStep = 0.001
+        self.probeSemiangle = 20.0
+        self.detectorAngleStep = 1.0
         self.probeXtilt = 0.0
         self.probeYtilt = 0.0
         self.scanWindowXMin = 0.0
@@ -258,7 +259,7 @@ class Metadata:
         self.savePotentialSlices = False
         self.nyquistSampling = False
         self.integrationAngleMin = 0
-        self.integrationAngleMax = 0.001
+        self.integrationAngleMax = 1.0
         self.transferMode = "auto"
         for k, v in kwargs.items():
             if k not in Metadata.fields:

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -62,6 +62,7 @@ class Metadata:
     "randomSeed" : number to use for random seeding of thermal effects
     "algorithm" : simulation algorithm to use, "prism" or "multislice"
     "includeThermalEffects" : true/false to apply random thermal displacements (Debye-Waller effect)
+    "includeOccupancy" : true/false to consider occupancy values for likelihood of atoms existing at each site
     "alsoDoCPUWork" : true/false
     "save2DOutput" : save the 2D STEM image integrated between integrationAngleMin and integrationAngleMax
     "save3DOutput" : true/false Also save the 3D output at the detector for each probe (3D output mode)
@@ -114,6 +115,7 @@ class Metadata:
         "randomSeed",
         "algorithm",
         "includeThermalEffects",
+        "includeOccupancy",
         "alsoDoCPUWork",
         "save2DOutput",
         "save3DOutput",
@@ -238,6 +240,7 @@ class Metadata:
         self.randomSeed = np.random.randint(0, 999999)
         self.algorithm = "prism"
         self.includeThermalEffects = False
+        self.includeOccupancy = True
         self.alsoDoCPUWork = True
         self.save2DOutput = False
         self.save3DOutput = True


### PR DESCRIPTION
- [x] Fix passing `includeOccupancy` in pyprismatic,
- [x] display and save simulation run time (optional).