### PR TITLE
Use emd extension instead of h5 

### DIFF
--- a/include/meta.h
+++ b/include/meta.h
@@ -32,7 +32,7 @@ namespace Prismatic{
             interpolationFactorY  = 4;
             interpolationFactorX  = 4;
             filenameAtoms         = "/path/to/atoms.txt";
-            filenameOutput        = "output.h5";
+            filenameOutput        = "output.emd";
             outputFolder          = "";
             realspacePixelSize[0] = 0.1;
             realspacePixelSize[1] = 0.1;
@@ -40,7 +40,7 @@ namespace Prismatic{
             numFP                 = 1;
             fpNum                 = 1;
             sliceThickness        = 2.0;
-            numSlices             = 0; 
+            numSlices             = 0;
             zStart                = 0.0;
             cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
             tileX                 = 1;

--- a/pyprismatic/__init__.py
+++ b/pyprismatic/__init__.py
@@ -46,7 +46,7 @@ def demo():
 14  4.0725  4.0725  4.0725  1.0  0.076\n\
 -1"
         )
-    meta = Metadata(filenameAtoms="temp.XYZ", filenameOutput="demo.h5")
+    meta = Metadata(filenameAtoms="temp.XYZ", filenameOutput="demo.emd")
     meta.algorithm = "multislice"
     meta.go()
     import numpy as np
@@ -54,8 +54,8 @@ def demo():
     import h5py
     #result = readMRC("output.mrc")
 
-    demoFile = h5py.File('demo.h5','r')
-    print('demo.h5 filestructure:')
+    demoFile = h5py.File('demo.emd','r')
+    print('demo.emd filestructure:')
     keySearch(demoFile,0)
 
     os.remove("temp.XYZ")

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -194,7 +194,7 @@ class Metadata:
         self.interpolationFactorX = 4
         self.interpolationFactorY = 4
         self.filenameAtoms = ""
-        self.filenameOutput = "output.h5"
+        self.filenameOutput = "output.emd"
         self.realspacePixelSizeX = 0.1
         self.realspacePixelSizeY = 0.1
         self.potBound = 1.0


### PR DESCRIPTION
Since prismatic generate h5py file with Berkeley emd specification and the corresponding extension is emd (https://emdatasets.com/format).

It would be good to add a link to https://emdatasets.com/format in the output section of the documentation (https://prism-em.com/docs-outputs).