### PR TITLE
MNT: Re-rendered with conda-build 3.20.3, conda-smithy 3.8.1, and con…

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -6,31 +6,36 @@ jobs:
 - job: linux
   pool:
     vmImage: ubuntu-16.04
-  timeoutInMinutes: 360
   strategy:
-    maxParallel: 8
     matrix:
-      linux_cuda_compiler_version10.0:
-        CONFIG: linux_cuda_compiler_version10.0
-        UPLOAD_PACKAGES: True
+      linux_64_c_compiler_version7cuda_compiler_version10.0cxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cuda_compiler_version10.0cxx_compiler_version7
+        UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
-      linux_cuda_compiler_version10.1:
-        CONFIG: linux_cuda_compiler_version10.1
-        UPLOAD_PACKAGES: True
+      linux_64_c_compiler_version7cuda_compiler_version10.1cxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cuda_compiler_version10.1cxx_compiler_version7
+        UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
-      linux_cuda_compiler_version10.2:
-        CONFIG: linux_cuda_compiler_version10.2
-        UPLOAD_PACKAGES: True
+      linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7
+        UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
-      linux_cuda_compiler_version9.2:
-        CONFIG: linux_cuda_compiler_version9.2
-        UPLOAD_PACKAGES: True
+      linux_64_c_compiler_version7cuda_compiler_version9.2cxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cuda_compiler_version9.2cxx_compiler_version7
+        UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
-      linux_cuda_compiler_versionNone:
-        CONFIG: linux_cuda_compiler_versionNone
-        UPLOAD_PACKAGES: True
+      linux_64_c_compiler_version7cuda_compiler_versionNonecxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cuda_compiler_versionNonecxx_compiler_version7
+        UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+  timeoutInMinutes: 360
+
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+    displayName: Manage disk space
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
@@ -42,6 +47,7 @@ jobs:
   - script: |
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,72 +5,22 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.14
-  timeoutInMinutes: 360
+    vmImage: macOS-10.15
   strategy:
-    maxParallel: 8
     matrix:
-      osx_:
-        CONFIG: osx_
-        UPLOAD_PACKAGES: True
+      osx_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10:
+        CONFIG: osx_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
 
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      echo "Fast Finish"
-      
-
-  - script: |
-      echo "Removing homebrew from Azure to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-    displayName: Remove homebrew
-
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: Add conda to PATH
-
-  - script: |
-      source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    displayName: 'Add conda-forge-ci-setup=2'
-
-  - script: |
-      source activate base
-      echo "Configuring conda."
-
-      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
-      source run_conda_forge_build_setup
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-    env: {
-      OSX_FORCE_SDK_DOWNLOAD: "1"
-    }
-    displayName: Configure conda and conda-build
-
-  - script: |
-      source activate base
-      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Mangle compiler
-
-  - script: |
-      source activate base
-      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Generate build number clobber file
-
-  - script: |
-      source activate base
-      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-    displayName: Build recipe
-
-  - script: |
-      source activate base
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Upload package
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -6,20 +6,16 @@ jobs:
 - job: win
   pool:
     vmImage: vs2017-win2016
-  timeoutInMinutes: 360
   strategy:
-    maxParallel: 4
     matrix:
-      win_:
-        CONFIG: win_
-        CONDA_BLD_PATH: D:\\bld\\
-        UPLOAD_PACKAGES: True
-  steps:
-    # TODO: Fast finish on azure pipelines?
-    - script: |
-        ECHO ON
-        
+      win_64_cuda_compiler_versionNone:
+        CONFIG: win_64_cuda_compiler_versionNone
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
 
+  steps:
     - script: |
         choco install vcpython27 -fdv -y --debug
       condition: contains(variables['CONFIG'], 'vs2008')
@@ -56,15 +52,19 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
 
     # Configure the VM
-    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
 
     # Configure the VM.
     - script: |
@@ -73,11 +73,6 @@ jobs:
         run_conda_forge_build_setup
       displayName: conda-forge build setup
     
-
-    - script: |
-        rmdir C:\strawberry /s /q
-      continueOnError: true
-      displayName: remove strawberryperl
 
     # Special cased version setting some more things!
     - script: |
@@ -99,8 +94,9 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.0cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.0cxx_compiler_version7.yaml
@@ -1,7 +1,7 @@
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -13,13 +13,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '9.2'
+- '10.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:9.2
+- condaforge/linux-anvil-cuda:10.0
 fftw:
 - '3'
 hdf5:
@@ -39,8 +39,13 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.1cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.1cxx_compiler_version7.yaml
@@ -1,7 +1,7 @@
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -13,13 +13,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '10.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.2
+- condaforge/linux-anvil-cuda:10.1
 fftw:
 - '3'
 hdf5:
@@ -39,8 +39,13 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7.yaml
@@ -1,7 +1,7 @@
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -13,13 +13,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- None
+- '10.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.2
 fftw:
 - '3'
 hdf5:
@@ -39,8 +39,13 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version9.2cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version9.2cxx_compiler_version7.yaml
@@ -1,7 +1,7 @@
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -13,13 +13,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.0'
+- '9.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:9.2
 fftw:
 - '3'
 hdf5:
@@ -39,8 +39,13 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_versionNonecxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_versionNonecxx_compiler_version7.yaml
@@ -1,7 +1,7 @@
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -13,13 +13,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.1
+- condaforge/linux-anvil-comp7
 fftw:
 - '3'
 hdf5:
@@ -39,8 +39,13 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/osx_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10.yaml
+++ b/.ci_support/osx_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10.yaml
@@ -1,19 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
-- vs2017
+- clang
+c_compiler_version:
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cuda_compiler_version:
+- None
 cxx_compiler:
-- vs2017
+- clangxx
+cxx_compiler_version:
+- '10'
 fftw:
 - '3'
 hdf5:
 - 1.10.5
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -29,5 +39,11 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -1,29 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 boost:
-- 1.70.0
+- 1.72.0
 boost_cpp:
-- 1.70.0
+- 1.72.0
 c_compiler:
-- clang
-c_compiler_version:
-- '9'
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cuda_compiler_version:
+- None
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '9'
+- vs2017
 fftw:
 - '3'
 hdf5:
 - 1.10.5
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -39,5 +31,8 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
+- 3.8.* *_cpython
 qt:
 - '5.12'
+target_platform:
+- win-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -29,11 +29,24 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -13,6 +13,10 @@ PROVIDER_DIR="$(basename $THISDIR)"
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -52,21 +56,27 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
+           -e BINSTAR_TOKEN \
            $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package  ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)


### PR DESCRIPTION
This PR updates the conda recipe as per https://conda-forge.org/docs/user/ci-skeleton.html#rerender.

With the recent changes of #88, only linux build fine, windows and macos have build failures.
From log https://dev.azure.com/ericpre/prismatic/_build/results?buildId=996&view=results:

Windows
```
2020-10-12T10:08:29.8016773Z [ 26%] Building CXX object CMakeFiles/prismatic.dir/src/PRISM01_calcPotential.cpp.obj
2020-10-12T10:08:29.8300020Z cl : Command line warning D9025 : overriding '/W3' with '/W0'
2020-10-12T10:08:29.8311138Z PRISM01_calcPotential.cpp
2020-10-12T10:08:31.3140472Z D:\bld\prismatic_1602496422089\work\src\PRISM01_calcPotential.cpp(365): error C2677: binary '*': no global operator found which takes type '_Fcomplex' (or there is no acceptable conversion)
2020-10-12T10:08:31.3142618Z D:\bld\prismatic_1602496422089\work\src\PRISM01_calcPotential.cpp(366): error C2677: binary '*': no global operator found which takes type '_Fcomplex' (or there is no acceptable conversion)
2020-10-12T10:08:31.4234856Z D:\bld\prismatic_1602496422089\work\src\PRISM01_calcPotential.cpp(577): error C2397: conversion from 'PRISMATIC_FLOAT_PRECISION' to '_Ty' requires a narrowing conversion
2020-10-12T10:08:31.4236775Z         with
2020-10-12T10:08:31.4237472Z         [
2020-10-12T10:08:31.4238196Z             _Ty=size_t
2020-10-12T10:08:31.4238947Z         ]
2020-10-12T10:08:31.4703957Z NMAKE : fatal error U1077: 'C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\cl.exe' : return code '0x2'
2020-10-12T10:08:31.4705353Z Stop.
2020-10-12T10:08:31.4741127Z NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
2020-10-12T10:08:31.4743723Z Stop.
2020-10-12T10:08:31.4760907Z NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
2020-10-12T10:08:31.4762123Z Stop.
2020-10-12T10:08:33.4914448Z Traceback (most recent call last):
2020-10-12T10:08:33.4915911Z   File "C:\Miniconda\Scripts\conda-build-script.py", line 10, in <module>
2020-10-12T10:08:33.4916778Z     sys.exit(main())
2020-10-12T10:08:33.4917834Z   File "C:\Miniconda\lib\site-packages\conda_build\cli\main_build.py", line 474, in main
2020-10-12T10:08:33.4923269Z     execute(sys.argv[1:])
2020-10-12T10:08:33.4924280Z   File "C:\Miniconda\lib\site-packages\conda_build\cli\main_build.py", line 465, in execute
2020-10-12T10:08:33.4927143Z     verify=args.verify, variants=args.variants)
2020-10-12T10:08:33.4928523Z   File "C:\Miniconda\lib\site-packages\conda_build\api.py", line 195, in build
2020-10-12T10:08:33.4932958Z     variants=variants
2020-10-12T10:08:33.4933971Z   File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 3005, in build_tree
2020-10-12T10:08:33.4947672Z     notest=notest,
2020-10-12T10:08:33.4949111Z   File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 2285, in build
2020-10-12T10:08:33.4960610Z     newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
2020-10-12T10:08:33.4962957Z   File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 1534, in bundle_conda
2020-10-12T10:08:33.4968052Z     cwd=metadata.config.work_dir, env=env_output, stats=bundle_stats)
2020-10-12T10:08:33.4969811Z   File "C:\Miniconda\lib\site-packages\conda_build\utils.py", line 410, in check_call_env
2020-10-12T10:08:33.4971908Z     return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
2020-10-12T10:08:33.4973222Z   File "C:\Miniconda\lib\site-packages\conda_build\utils.py", line 390, in _func_defaulting_env_to_os_environ
2020-10-12T10:08:33.4977290Z     raise subprocess.CalledProcessError(proc.returncode, _args)
2020-10-12T10:08:33.4980483Z subprocess.CalledProcessError: Command '['C:\\windows\\system32\\cmd.exe', '/d', '/c', 'D:\\bld\\prismatic_1602496422089\\work\\output_script.bat']' returned non-zero exit status 1.
2020-10-12T10:08:36.4417126Z ##[error]Cmd.exe exited with code '1'.
2020-10-12T10:08:36.5095145Z ##[section]Finishing: Build recipe
```

MacOS
```
2020-10-12T09:58:24.3920460Z [ 26%] Building CXX object CMakeFiles/prismatic.dir/src/PRISM01_calcPotential.cpp.o
2020-10-12T09:58:25.9549570Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:365:25: error: use of undeclared identifier 'I'
2020-10-12T09:58:25.9551000Z                         qyShift.at(j,i) = -2*I*pi*qya.at(j,i);
2020-10-12T09:58:25.9551580Z                                              ^
2020-10-12T09:58:25.9589030Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:366:25: error: use of undeclared identifier 'I'
2020-10-12T09:58:25.9590430Z                         qxShift.at(j,i) = -2*I*pi*qxa.at(j,i);
2020-10-12T09:58:25.9590990Z                                              ^
2020-10-12T09:58:25.9840450Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:577:86: error: type 'double' cannot be narrowed to 'unsigned long' in initializer list [-Wc++11-narrowing]
2020-10-12T09:58:25.9842270Z                 Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{zleng*2}});
2020-10-12T09:58:25.9844230Z                                                                                                    ^~~~~~~
2020-10-12T09:58:25.9846110Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:577:86: note: insert an explicit cast to silence this issue
2020-10-12T09:58:25.9847700Z                 Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{zleng*2}});
2020-10-12T09:58:25.9848750Z                                                                                                    ^~~~~~~
2020-10-12T09:58:25.9849790Z                                                                                                    static_cast<unsigned long>( )
2020-10-12T09:58:26.3722290Z 3 errors generated.
2020-10-12T09:58:26.3785500Z make[2]: *** [CMakeFiles/prismatic.dir/build.make:134: CMakeFiles/prismatic.dir/src/PRISM01_calcPotential.cpp.o] Error 1
2020-10-12T09:58:26.3786420Z make[2]: *** Waiting for unfinished jobs....
2020-10-12T09:58:27.4018190Z make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/prismatic.dir/all] Error 2
2020-10-12T09:58:27.4019220Z make: *** [Makefile:149: all] Error 2
2020-10-12T09:58:27.5152280Z [  5%] Building CXX object CMakeFiles/prismatic.dir/src/PRISM01_calcPotential.cpp.o
2020-10-12T09:58:29.2969630Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:365:25: error: use of undeclared identifier 'I'
2020-10-12T09:58:29.2971500Z                         qyShift.at(j,i) = -2*I*pi*qya.at(j,i);
2020-10-12T09:58:29.2972080Z                                              ^
2020-10-12T09:58:29.2973140Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:366:25: error: use of undeclared identifier 'I'
2020-10-12T09:58:29.2974240Z                         qxShift.at(j,i) = -2*I*pi*qxa.at(j,i);
2020-10-12T09:58:29.2974780Z                                              ^
2020-10-12T09:58:29.2975970Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:577:86: error: type 'double' cannot be narrowed to 'unsigned long' in initializer list [-Wc++11-narrowing]
2020-10-12T09:58:29.2976920Z                 Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{zleng*2}});
2020-10-12T09:58:29.2977620Z                                                                                                    ^~~~~~~
2020-10-12T09:58:29.2978970Z /Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/src/PRISM01_calcPotential.cpp:577:86: note: insert an explicit cast to silence this issue
2020-10-12T09:58:29.2980650Z                 Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{zleng*2}});
2020-10-12T09:58:29.2982570Z                                                                                                    ^~~~~~~
2020-10-12T09:58:29.2984590Z                                                                                                    static_cast<unsigned long>( )
2020-10-12T09:58:29.4226740Z 3 errors generated.
2020-10-12T09:58:29.4288810Z make[2]: *** [CMakeFiles/prismatic.dir/build.make:134: CMakeFiles/prismatic.dir/src/PRISM01_calcPotential.cpp.o] Error 1
2020-10-12T09:58:29.4291100Z make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/prismatic.dir/all] Error 2
2020-10-12T09:58:29.4293770Z make: *** [Makefile:149: all] Error 2
2020-10-12T09:58:30.1646320Z Traceback (most recent call last):
2020-10-12T09:58:30.1647920Z   File "/Users/runner/miniforge3/bin/conda-build", line 11, in <module>
2020-10-12T09:58:30.1648580Z     sys.exit(main())
2020-10-12T09:58:30.1649580Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/cli/main_build.py", line 474, in main
2020-10-12T09:58:30.1650540Z     execute(sys.argv[1:])
2020-10-12T09:58:30.1652160Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/cli/main_build.py", line 463, in execute
2020-10-12T09:58:30.1653210Z     outputs = api.build(args.recipe, post=args.post, test_run_post=args.test_run_post,
2020-10-12T09:58:30.1654560Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/api.py", line 186, in build
2020-10-12T09:58:30.1655270Z     return build_tree(
2020-10-12T09:58:30.1656760Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/build.py", line 3000, in build_tree
2020-10-12T09:58:30.1662450Z     packages_from_this = build(metadata, stats,
2020-10-12T09:58:30.1663990Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/build.py", line 2285, in build
2020-10-12T09:58:30.1668650Z     newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
2020-10-12T09:58:30.1669840Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/build.py", line 1533, in bundle_conda
2020-10-12T09:58:30.1672880Z     utils.check_call_env(interpreter_and_args + [dest_file],
2020-10-12T09:58:30.1674470Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/utils.py", line 410, in check_call_env
2020-10-12T09:58:30.1676090Z     return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
2020-10-12T09:58:30.1677720Z   File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_build/utils.py", line 390, in _func_defaulting_env_to_os_environ
2020-10-12T09:58:30.1678840Z     raise subprocess.CalledProcessError(proc.returncode, _args)
2020-10-12T09:58:30.1680910Z subprocess.CalledProcessError: Command '['/bin/bash', '-e', '/Users/runner/miniforge3/conda-bld/prismatic_1602496206757/work/output_script.sh']' returned non-zero exit status 2.
2020-10-12T09:58:32.3983930Z 
2020-10-12T09:58:32.4046480Z ##[error]Bash exited with code '1'.
2020-10-12T09:58:32.4098790Z ##[section]Finishing: Run OSX build
```