### PR TITLE
fixing macOS build errors

### DIFF
--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -28,7 +28,7 @@
 #include "utility.h"
 #include "fileIO.h"
 #include "fftw3.h"
-#include "complex.h"
+#include <complex>
 
 #ifdef PRISMATIC_BUILDING_GUI
 #include "prism_progressbar.h"
@@ -362,8 +362,8 @@ void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 	{
 		for(auto i = 0; i < qya.get_dimi(); i++)
 		{
-			qyShift.at(j,i) = -2*I*pi*qya.at(j,i);
-			qxShift.at(j,i) = -2*I*pi*qxa.at(j,i);
+			qyShift.at(j,i) = -2.0*i*pi*qya.at(j,i);
+			qxShift.at(j,i) = -2.0*i*pi*qxa.at(j,i);
 		}
 	}
 
@@ -574,7 +574,7 @@ void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 
 		pars.dzPot = pars.meta.sliceThickness/pars.meta.zSampling;
         PRISMATIC_FLOAT_PRECISION zleng = std::ceil(pars.meta.potBound/pars.dzPot);
-		Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{zleng*2}});
+		Array1D<PRISMATIC_FLOAT_PRECISION> zvec = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{(size_t)zleng*2}});
 		for (auto j = -zleng; j < zleng; j++)
 		{
 			zvec[j+zleng] = (PRISMATIC_FLOAT_PRECISION) j + 0.5;

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -1164,7 +1164,7 @@ void writeMetadata(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 	tmp_buffer[1] = pars.meta.scanWindowYMax;
 	scanWindow_y_attr.write(PFP_TYPE, tmp_buffer);
 
-	int tile_buffer[3] = {pars.meta.tileX, pars.meta.tileY, pars.meta.tileZ};
+	int tile_buffer[3] = {(int)pars.meta.tileX, (int)pars.meta.tileY, (int)pars.meta.tileZ};
 	tile_attr.write(H5::PredType::NATIVE_INT, tile_buffer);
 
 	PRISMATIC_FLOAT_PRECISION cellBuffer[3] = {pars.meta.cellDim[2], pars.meta.cellDim[1], pars.meta.cellDim[0]};

--- a/src/projectedPotential.cpp
+++ b/src/projectedPotential.cpp
@@ -40,8 +40,8 @@ PRISMATIC_FLOAT_PRECISION get_potMin(const Array2D<PRISMATIC_FLOAT_PRECISION> &p
 	// const PRISMATIC_FLOAT_PRECISION xv[] = {xInd - dx, xInd + dx, xInd - dx, xInd + dx, 0, 0, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1};
 	// const PRISMATIC_FLOAT_PRECISION yv[] = {0, 0, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, yInd - dy, yInd + dy, yInd - dy, yInd + dy};
 
-	const PRISMATIC_FLOAT_PRECISION xv[] = {(PRISMATIC_FLOAT_PRECISION)xr.size() - 2, xInd}; //-2 to gaurantee zero faces
-	const PRISMATIC_FLOAT_PRECISION yv[] = {yInd, (PRISMATIC_FLOAT_PRECISION)yr.size() - 2};
+	const PRISMATIC_FLOAT_PRECISION xv[] = {(PRISMATIC_FLOAT_PRECISION)xr.size() - 2, (PRISMATIC_FLOAT_PRECISION)xInd}; //-2 to gaurantee zero faces
+	const PRISMATIC_FLOAT_PRECISION yv[] = {(PRISMATIC_FLOAT_PRECISION)yInd, (PRISMATIC_FLOAT_PRECISION)yr.size() - 2};
 
 	PRISMATIC_FLOAT_PRECISION potMin = 0;
 	for (auto i = 0; i < 2; ++i)


### PR DESCRIPTION
Fix a few build errors on macOS. This should fix all the build errors reported in #89. One warning remains:

```
[  2%] Automatic MOC and UIC for target prismatic-gui
[  4%] Linking CXX executable prismatic
[ 42%] Built target prismatic
[ 42%] Built target prismatic-gui_autogen
[ 44%] Automatic RCC for Qt/prism_resources.qrc
Scanning dependencies of target prismatic-gui
[ 46%] Building CXX object CMakeFiles/prismatic-gui.dir/Qt/prismmainwindow.cpp.o
[ 48%] Building CXX object CMakeFiles/prismatic-gui.dir/Qt/prism_progressbar.cpp.o
[ 51%] Building CXX object CMakeFiles/prismatic-gui.dir/prismatic-gui_autogen/mocs_compilation.cpp.o
[ 53%] Building CXX object CMakeFiles/prismatic-gui.dir/Qt/saveatomiccoordinatesdialog.cpp.o
[ 55%] Building CXX object CMakeFiles/prismatic-gui.dir/prismatic-gui_autogen/4DVC4UZSMN/qrc_prism_resources.cpp.o
/Users/sez/git-repos/prismatic/Qt/prismmainwindow.cpp:435:13: warning: enumeration value 'HRTEM' not handled in
      switch [-Wswitch]
    switch (this->meta->algorithm){
            ^
/Users/sez/git-repos/prismatic/Qt/prismmainwindow.cpp:435:13: note: add missing switch cases
    switch (this->meta->algorithm){
            ^
Copying OS X content prismatic-gui.app/Contents/Resources/prismatic-icon.icns
1 warning generated.
[ 57%] Linking CXX executable prismatic-gui.app/Contents/MacOS/prismatic-gui
[100%] Built target prismatic-gui
```