### PR TITLE
Make h5py and matplotlib optional dependency

### DIFF
--- a/pyprismatic/__init__.py
+++ b/pyprismatic/__init__.py
@@ -49,13 +49,14 @@ def demo():
     meta = Metadata(filenameAtoms="temp.XYZ", filenameOutput="demo.h5")
     meta.algorithm = "multislice"
     meta.go()
-    import numpy as np
-    #from pyprismatic.fileio import readMRC
-    import h5py
-    #result = readMRC("output.mrc")
 
-    demoFile = h5py.File('demo.h5','r')
-    print('demo.h5 filestructure:')
-    keySearch(demoFile,0)
+    try:
+        import h5py
+
+        demoFile = h5py.File('demo.h5','r')
+        print('demo.h5 filestructure:')
+        keySearch(demoFile, 0)
+    except ImportError:
+        pass
 
     os.remove("temp.XYZ")

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -272,8 +272,8 @@ class Metadata:
 
     @filenameAtoms.setter
     def filenameAtoms(self, filenameAtoms):
+        self._filenameAtoms = filenameAtoms
         if filenameAtoms != "":  # do not set cell dimensions for default empty string
-            self._filenameAtoms = filenameAtoms
             self._setCellDims(filenameAtoms)
 
     def readParameters(self, filename: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 numpy>=1.13.0
-matplotlib>=2.0.2
-h5py>=2.9.0

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     description="Python wrapper for Prismatic package for fast image simulation using the PRISM and multislice algorithms in Scanning Transmission Electron Microscopy (STEM)",
     ext_modules=[CMakeExtension(c_module_name)],
     packages=["pyprismatic"],
-    install_requires=["numpy>=1.13.0", "matplotlib>=2.0.2","h5py>=2.9.0"],
+    install_requires=["numpy>=1.13.0"],
     cmdclass={"install": InstallCommand,
     "develop":DevelopCommand,
     "build_ext":cmake_build_ext},


### PR DESCRIPTION
Make h5py and matplotlib optional dependency to be able to run the demo without these installed, which is useful to check quickly if the install is working.