### PR TITLE
Increase compute capability for cuda110

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(OUTPUT_NAME prismatic CACHE STRING OUTPUT_NAME)
 
 #set (CMAKE_BUILD_TYPE DEBUG)
 if (PRISMATIC_ENABLE_GPU)
-    set(NVCC_FLAGS_EXTRA "-arch=sm_30 -std=c++11 -Xcompiler -fPIC")
+    set(NVCC_FLAGS_EXTRA "-arch=sm_60 -std=c++11 -Xcompiler -fPIC")
 endif (PRISMATIC_ENABLE_GPU)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
@@ -344,7 +344,7 @@ if (PRISMATIC_TESTS)
         add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all
                             DEPENDS prismatic prismatic-tests)
     endif(PRISMATIC_ENABLE_PYPRISMATIC)
-       
+
 
 endif (PRISMATIC_TESTS)
 

--- a/include/utility.cuh
+++ b/include/utility.cuh
@@ -236,8 +236,5 @@ __global__ void DPC_denominator_reduce(const double* psiIntensity_ds,
 //size_t getNextPower2(const float& val);
 size_t getNextPower2(const size_t& val);
 
-#if __CUDA_ARCH__ < 600
-__device__  double atomicAdd_double(double* address, const double val);
-#endif
 //__global__ void shiftIndices(size_t* vec, const size_t* vec_in, double by, const size_t N);
 #endif // PRISMATIC_UTILITY_CUH


### PR DESCRIPTION
Set nvcc arch flag to sm_60 instead of sm_30 to be compatible with cuda110 and remove `atomicAdd_double` which was necessary for compute capability<6.