### PR TITLE
Updated params.py to the correct units

### DIFF
--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -34,8 +34,8 @@ class Metadata:
     "tileX" : number of unit cells to tile in X direction
     "tileY" : number of unit cells to tile in Y direction
     "tileZ" : number of unit cells to tile in Z direction
-    "E0" : electron beam energy (in eV)
-    "alphaBeamMax" : the maximum probe angle to consider (in rad)
+    "E0" : electron beam energy (in KeV)
+    "alphaBeamMax" : the maximum probe angle to consider (in mrad)
     "numGPUs" : number of GPUs to use. A runtime check is performed to check how many are actually available, and the minimum of these two numbers is used.
     "numStreamsPerGPU" : number of CUDA streams to use per GPU
     "numThreads" : number of CPU worker threads to use
@@ -47,8 +47,8 @@ class Metadata:
     "probeDefocus" : probe defocus (in Angstroms)
     "C3" : microscope C3 (in Angstroms)
     "C5" : microscope C5 (in Angstroms)
-    "probeSemiangle" : probe convergence semi-angle (in rad)
-    "detectorAngleStep" : angular step size for detector integration bins (in rad)
+    "probeSemiangle" : probe convergence semi-angle (in mrad)
+    "detectorAngleStep" : angular step size for detector integration bins (in mrad)
     "probeXtilt" : (in Angstroms)
     "probeYtilt" : (in Angstroms)
     "scanWindowXMin" : lower X size of the window to scan the probe (in fractional coordinates)
@@ -69,8 +69,8 @@ class Metadata:
     "saveDPC_CoM"  : true/false Also save the DPC center of mass calculation for each probe
     "savePotentialSlices" : true/false Also save the projected potential array
     "nyquistSampling": set number of probe positions at Nyquist sampling limit
-    "integrationAngleMin" : (in rad)
-    "integrationAngleMax" : (in rad)
+    "integrationAngleMin" : (in mrad)
+    "integrationAngleMax" : (in mrad)
     "transferMode" : memory model to use, either "streaming", "singlexfer", or "auto"
     """
 
@@ -208,8 +208,8 @@ class Metadata:
         self.tileX = 3
         self.tileY = 3
         self.tileZ = 1
-        self.E0 = 80e3
-        self.alphaBeamMax = 0.024
+        self.E0 = 80
+        self.alphaBeamMax = 24.0
         self.numGPUs = 4
         self.numStreamsPerGPU = 3
         self.numThreads = 12
@@ -223,8 +223,8 @@ class Metadata:
         self.probeDefocus = 0.0
         self.C3 = 0.0
         self.C5 = 0.0
-        self.probeSemiangle = 0.02
-        self.detectorAngleStep = 0.001
+        self.probeSemiangle = 20.0
+        self.detectorAngleStep = 1.0
         self.probeXtilt = 0.0
         self.probeYtilt = 0.0
         self.scanWindowXMin = 0.0
@@ -246,7 +246,7 @@ class Metadata:
         self.savePotentialSlices = False
         self.nyquistSampling = False
         self.integrationAngleMin = 0
-        self.integrationAngleMax = 0.001
+        self.integrationAngleMax = 1.0
         self.transferMode = "auto"
         for k, v in kwargs.items():
             if k not in Metadata.fields:

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -34,7 +34,7 @@ class Metadata:
     "tileX" : number of unit cells to tile in X direction
     "tileY" : number of unit cells to tile in Y direction
     "tileZ" : number of unit cells to tile in Z direction
-    "E0" : electron beam energy (in KeV)
+    "E0" : electron beam energy (in keV)
     "alphaBeamMax" : the maximum probe angle to consider (in mrad)
     "numGPUs" : number of GPUs to use. A runtime check is performed to check how many are actually available, and the minimum of these two numbers is used.
     "numStreamsPerGPU" : number of CUDA streams to use per GPU


### PR DESCRIPTION
 I noticed an inconsistency in units used in pyprismatic `params.py` and `core.cpp`, also mentioned in #82 


- adjusted docstrings to reflect the units of beam energy (E0), and angles (alphaBeamMax, probeSemiangle, detectorAngleStep, integrationAngleMin, and integrationAngleMax) to be in keV and mrad rather than ev and rad.  
- adjusted `self.E0`  `self.alphaBeamMax`, `self.probeSemiangle`, `self.detectorAngleStep`, `self.integrationAngleMin` and `self.integrationAngleMax` values to reflect new units.