### PR TITLE
Variety of bug fixes; add q-array saving for HRTEM to dev functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,10 +338,10 @@ if (PRISMATIC_TESTS)
 
     # always run tests last
     if(PRISMATIC_ENABLE_PYPRISMATIC)
-        add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all
+        add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all --run_test=NONE
                             DEPENDS prismatic prismatic-tests pyprismatic_core)
     else(PRISMATIC_ENABLE_PYPRISMATIC)
-        add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all
+        add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all --run_test=NONE
                             DEPENDS prismatic prismatic-tests)
     endif(PRISMATIC_ENABLE_PYPRISMATIC)
 

--- a/include/meta.h
+++ b/include/meta.h
@@ -44,7 +44,7 @@ namespace Prismatic{
             numFP                 = 1;
             fpNum                 = 1;
             sliceThickness        = 2.0;
-            zSampling             = 4;
+            zSampling             = 16;
             numSlices             = 0; 
             zStart                = 0.0;
             cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format

--- a/include/meta.h
+++ b/include/meta.h
@@ -63,13 +63,13 @@ namespace Prismatic{
             earlyCPUStopCount     = 100; // relative speed of job completion between gpu and cpu, used to determine early stopping point for cpu work
             probeStepX            = 0.25;
             probeStepY            = 0.25;
-            probeDefocus          = 0.0;
+            probeDefocus          = (T) nan("");
             probeDefocus_min      = 0.0;
             probeDefocus_max      = 0.0;
             probeDefocus_step     = 0.0;
             probeDefocus_sigma    = 0.0;
-            C3                    = 0.0;
-            C5                    = 0.0;
+            C3                    = (T) nan("");
+            C5                    = (T) nan("");
             aberrations           = {};
             probeSemiangle        = 20.0 / 1000;
             detectorAngleStep     = 1.0 / 1000;

--- a/include/utility.h
+++ b/include/utility.h
@@ -52,11 +52,23 @@ Array1D<T> makeFourierCoords(const size_t &N, const T &pixel_size)
 	Array1D<T> result = zeros_ND<1, T>({{N}});
 	long long nc = (size_t)floor((T)N / 2);
 
-	T dp = 1 / (N * pixel_size);
-	for (auto i = 0; i < N; ++i)
-	{
-		result[(nc + (size_t)i) % N] = (i - nc) * dp;
-	}
+	T dp;
+    if(N % 2) //odd case
+    {
+        dp = 1 / ((N-1) * pixel_size);
+        for (auto i = 0; i < N; ++i)
+        {
+            result[(nc + (size_t)i + 1) % N] = (i - nc) * dp;
+        }
+    }
+    else
+    {
+        dp = 1 / (N * pixel_size);
+        for (auto i = 0; i < N; ++i)
+        {
+            result[(nc + (size_t)i) % N] = (i - nc) * dp;
+        }
+    }
 	return result;
 };
 

--- a/pyprismatic/core.cpp
+++ b/pyprismatic/core.cpp
@@ -202,8 +202,12 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	meta.probeYtilt = probeYtilt / 1000;
 	meta.minXtilt = minXtilt / 1000;
 	meta.maxXtilt = maxXtilt / 1000;
+	meta.xTiltStep = xTiltStep /1000;
+	meta.xTiltOffset = xTiltOffset / 1000;
 	meta.minYtilt = minYtilt / 1000;
 	meta.maxYtilt = maxYtilt / 1000;
+	meta.yTiltStep = yTiltStep /1000;
+	meta.yTiltOffset = yTiltOffset / 1000;
 	meta.minRtilt = minRtilt / 1000;
 	meta.maxRtilt = maxRtilt / 1000;
 	meta.scanWindowXMin = scanWindowXMin;
@@ -214,6 +218,9 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	meta.scanWindowXMax_r = scanWindowXMax_r;
 	meta.scanWindowYMin_r = scanWindowYMin_r;
 	meta.scanWindowYMax_r = scanWindowYMax_r;
+	if(scanWindowXMax_r) meta.realSpaceWindow_x = true;
+	if(scanWindowYMax_r) meta.realSpaceWindow_y = true;
+
 	if(std::string(probes_file).size() > 0)
 	{
 		meta.arbitraryProbes = true;

--- a/pyprismatic/core.cpp
+++ b/pyprismatic/core.cpp
@@ -34,12 +34,13 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 		tileX, tileY, tileZ,
 		numGPUs, numStreamsPerGPU, numThreads, includeThermalEffects, includeOccupancy, alsoDoCPUWork,
 		save2DOutput, save3DOutput, save4DOutput, saveDPC_CoM, savePotentialSlices, nyquistSampling, crop4DOutput,
-		zSampling, numSlices, potential3D, saveSMatrix, importPotential, importSMatrix, saveComplexOutputWave, saveProbe, matrixRefocus, maxFileSize;
+		zSampling, numSlices, potential3D, saveSMatrix, importPotential, importSMatrix, saveComplexOutputWave, saveProbe, matrixRefocus, maxFileSize,
+        earlyCPUStopCount;
 	char *filenameAtoms, *filenameOutput, *algorithm, *transferMode,
 		 *aberrations_file, *probes_file, *importFile, *importPath;
 	double realspacePixelSizeX, realspacePixelSizeY, potBound,
 		sliceThickness, probeStepX, probeStepY,
-		cellDimX, cellDimY, cellDimZ, earlyCPUStopCount, E0, alphaBeamMax,
+		cellDimX, cellDimY, cellDimZ, E0, alphaBeamMax,
 		detectorAngleStep, probeDefocus, C3,
 		C5, probeSemiangle, probeXtilt,
 		probeYtilt, scanWindowXMin, scanWindowXMax,

--- a/pyprismatic/core.cpp
+++ b/pyprismatic/core.cpp
@@ -233,6 +233,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	{
 		meta.algorithm = Prismatic::Algorithm::HRTEM;
 	}
+	meta.potential3D = potential3D;
 	meta.includeThermalEffects = includeThermalEffects;
 	meta.includeOccupancy = includeOccupancy;
 	meta.alsoDoCPUWork = alsoDoCPUWork;

--- a/pyprismatic/core.cpp
+++ b/pyprismatic/core.cpp
@@ -34,7 +34,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 		tileX, tileY, tileZ,
 		numGPUs, numStreamsPerGPU, numThreads, includeThermalEffects, includeOccupancy, alsoDoCPUWork,
 		save2DOutput, save3DOutput, save4DOutput, saveDPC_CoM, savePotentialSlices, nyquistSampling, crop4DOutput,
-		zSampling, numSlices, potential3D, saveSMatrix, importPotential, importSMatrix, saveComplexOutputWave, saveProbe, matrixRefocus;
+		zSampling, numSlices, potential3D, saveSMatrix, importPotential, importSMatrix, saveComplexOutputWave, saveProbe, matrixRefocus, maxFileSize;
 	char *filenameAtoms, *filenameOutput, *algorithm, *transferMode,
 		 *aberrations_file, *probes_file, *importFile, *importPath;
 	double realspacePixelSizeX, realspacePixelSizeY, potBound,
@@ -56,7 +56,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	//d - double
 	//p - bool
 	if (!PyArg_ParseTuple( 
-			args, "iissdddidiiddddiiiddiiiiiidddddddddsddddddddddddddddddddddsispppppppddsppppdppppppss",
+			args, "iissdddidiiddddiiiddiiiiiidddddddddsddddddddddddddddddddddsispppppppddsppppdppppppssi",
 			&interpolationFactorX,
 			&interpolationFactorY,
 			&filenameAtoms,
@@ -140,7 +140,8 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 			&saveComplexOutputWave,
 			&matrixRefocus,
 			&importFile,
-			&importPath))
+			&importPath,
+			&maxFileSize))
 	{
 		return NULL;
 	}
@@ -259,6 +260,7 @@ static PyObject *pyprismatic_core_go(PyObject *self, PyObject *args)
 	meta.importSMatrix = importSMatrix;
 	meta.saveComplexOutputWave = saveComplexOutputWave;
 	meta.saveProbe = saveProbe;
+	meta.maxFileSize = maxFileSize;
 	meta.matrixRefocus = matrixRefocus;
 	meta.importFile = std::string(importFile);
 	meta.importPath = std::string(importPath);

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -257,7 +257,7 @@ class Metadata:
         self.potBound = 2.0
         self.numFP = 1
         self.sliceThickness = 2.0
-        self.zSampling = 4
+        self.zSampling = 16
         self.numSlices = 0
         self.zStart = 0.0
         self.cellDimX = 20.0

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -163,7 +163,8 @@ class Metadata:
         "saveComplexOutputWave",
         "matrixRefocus",
         "importFile",
-        "importPath"
+        "importPath",
+        "maxFileSize",
     ]
 
     str_fields: List[str] = [
@@ -190,6 +191,7 @@ class Metadata:
         "batchSizeGPU",
         "numSlices",
         "zSampling",
+        "maxFileSize",
     ]
 
     float_fields: List[str] = [
@@ -330,6 +332,7 @@ class Metadata:
         self.importSMatrix = False
         self.saveComplexOutputWave = False
         self.saveProbe = False
+        self.maxFileSize = 2*10**9 #to make sure python types as int
         self.matrixRefocus = False
         self.importFile = ""
         self.importPath = ""

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -280,13 +280,13 @@ class Metadata:
         self.earlyCPUStopCount = 100
         self.probeStepX = 0.25
         self.probeStepY = 0.25
-        self.probeDefocus = 0.0
+        self.probeDefocus = float("NaN")
         self.probeDefocus_min = 0.0
         self.probeDefocus_max = 0.0
         self.probeDefocus_step = 0.0
         self.probeDefocus_sigma = 0.0
-        self.C3 = 0.0
-        self.C5 = 0.0
+        self.C3 = float("NaN")
+        self.C5 = float("NaN")
         self.aberrations_file = ""
         self.probeSemiangle = 20.0
         self.detectorAngleStep = 1.0

--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -323,7 +323,7 @@ class Metadata:
         self.save3DOutput = True
         self.save4DOutput = False
         self.crop4DOutput = False
-        self.crop4Damax = 0.1
+        self.crop4Damax = 100.0
         self.saveDPC_CoM = False
         self.savePotentialSlices = False
         self.saveSMatrix = False

--- a/src/HRTEM_entry.cpp
+++ b/src/HRTEM_entry.cpp
@@ -85,6 +85,7 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 		{
 			if(i == 0)
 			{
+				sortHRTEMbeams(prismatic_pars); //sort beams early so that can put in right order as integrating
 				net_output = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.Scompact.get_dimi(), prismatic_pars.Scompact.get_dimj(), prismatic_pars.Scompact.get_dimk()}});
 			}
 			//integrate output
@@ -95,7 +96,7 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 				{
 					for(auto ii = 0; ii < prismatic_pars.Scompact.get_dimi(); ii++)
 					{
-						net_output.at(ii,jj,kk) += pow(std::abs(prismatic_pars.Scompact.at(kk,jj,ii)*scale), 2.0) / prismatic_pars.meta.numFP;
+						net_output.at(ii,jj,prismatic_pars.HRTEMbeamOrder[kk]) += pow(std::abs(prismatic_pars.Scompact.at(kk,jj,ii)*scale), 2.0) / prismatic_pars.meta.numFP;
 					}
 				}
 			}
@@ -109,7 +110,6 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 	if(not prismatic_pars.meta.saveComplexOutputWave)
 	{
 		std::cout << "Writing HRTEM data to output file." << std::endl;
-		sortHRTEMbeams(prismatic_pars);
 		setupHRTEMOutput(prismatic_pars);
 		setupHRTEMOutput_virtual(prismatic_pars);
 		saveHRTEM(prismatic_pars, net_output);

--- a/src/HRTEM_entry.cpp
+++ b/src/HRTEM_entry.cpp
@@ -96,7 +96,7 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 				{
 					for(auto ii = 0; ii < prismatic_pars.Scompact.get_dimi(); ii++)
 					{
-						net_output.at(ii,jj,prismatic_pars.HRTEMbeamOrder[kk]) += pow(std::abs(prismatic_pars.Scompact.at(kk,jj,ii)*scale), 2.0) / prismatic_pars.meta.numFP;
+						net_output.at(ii,jj,kk) += pow(std::abs(prismatic_pars.Scompact.at(prismatic_pars.HRTEMbeamOrder[kk],jj,ii)*scale), 2.0) / prismatic_pars.meta.numFP;
 					}
 				}
 			}

--- a/src/HRTEM_entry.cpp
+++ b/src/HRTEM_entry.cpp
@@ -85,10 +85,11 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 		{
 			if(i == 0)
 			{
-				sortHRTEMbeams(prismatic_pars); //sort beams early so that can put in right order as integrating
 				net_output = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{prismatic_pars.Scompact.get_dimi(), prismatic_pars.Scompact.get_dimj(), prismatic_pars.Scompact.get_dimk()}});
 			}
+
 			//integrate output
+            sortHRTEMbeams(prismatic_pars);
 			PRISMATIC_FLOAT_PRECISION scale = prismatic_pars.Scompact.get_dimj() * prismatic_pars.Scompact.get_dimi();
 			for(auto kk = 0; kk < prismatic_pars.Scompact.get_dimk(); kk++)
 			{

--- a/src/HRTEM_entry.cpp
+++ b/src/HRTEM_entry.cpp
@@ -57,18 +57,25 @@ Parameters<PRISMATIC_FLOAT_PRECISION> HRTEM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 	{
 		HRTEM_runFP(prismatic_pars, i);
 
-		//apply aberrations
-		if(prismatic_pars.meta.aberrations.size() > 0)
-		{
-			// setup necessary coordinates
-			setupCoordinates_2(prismatic_pars);
-			setupDetector(prismatic_pars);
-			setupFourierCoordinates(prismatic_pars);
-			transformIndices(prismatic_pars);
+		// //apply aberrations
+		// if(prismatic_pars.meta.aberrations.size() > 0)
+		// {
+        //     std::cout << "setting up coordinates for aberrations" << std::endl;
+		// 	// setup necessary coordinates
+		// 	setupCoordinates_2(prismatic_pars);
+
+
+        //     std::cout << "setting up detector" << std::endl;
+		// 	setupDetector(prismatic_pars);
+        //     std::cout << "setting up fourier" << std::endl;
+		// 	setupFourierCoordinates(prismatic_pars);
+        //     std::cout << "setting up indices" << std::endl;
+		// 	transformIndices(prismatic_pars);
 		
-			//now apply aberrations to each beam
-			apply_aberrations(prismatic_pars);
-		}
+        //     std::cout << "applying aberrations " << std::endl;
+		// 	//now apply aberrations to each beam
+		// 	apply_aberrations(prismatic_pars);
+		// }
 
 		if(prismatic_pars.meta.saveComplexOutputWave)
 		{			

--- a/src/Multislice_calcOutput.cpp
+++ b/src/Multislice_calcOutput.cpp
@@ -739,7 +739,6 @@ namespace Prismatic{
 		// If the batch size is too big, the work won't be spread over the threads, which will usually hurt more than the benefit
 		// of batch FFT
 		pars.meta.batchSizeCPU = min(pars.meta.batchSizeTargetCPU, max((size_t)1, pars.numProbes / pars.meta.numThreads));
-		std::cout <<"batch size at run: " << pars.meta.batchSizeCPU << std::endl;
 		for (auto t = 0; t < pars.meta.numThreads; ++t){
 			cout << "Launching CPU worker #" << t << endl;
 			workers.push_back(thread([&pars, &dispatcher, t, &PRISMATIC_PRINT_FREQUENCY_PROBES]() {

--- a/src/Multislice_entry.cpp
+++ b/src/Multislice_entry.cpp
@@ -182,7 +182,6 @@ void Multislice_series_runFP(Parameters<PRISMATIC_FLOAT_PRECISION> &pars, size_t
 		PRISM01_calcPotential(pars);
 	}
 
-	std::cout << "series val size: " <<  pars.meta.seriesVals[0].size() << std::endl;
 	for(auto i = 0; i < pars.meta.seriesVals[0].size(); i++)
 	{
 		std::cout << "------------------- Series iter " << i << " -------------------" << std::endl;

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -359,12 +359,14 @@ void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 	Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> qyShift = zeros_ND<2,std::complex<PRISMATIC_FLOAT_PRECISION>>({{qya.get_dimj(), qya.get_dimi()}});
 	Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> qxShift = zeros_ND<2,std::complex<PRISMATIC_FLOAT_PRECISION>>({{qya.get_dimj(), qya.get_dimi()}});
 	Array2D<PRISMATIC_FLOAT_PRECISION> q1(qya);
-	for(auto j = 0; j < qya.get_dimj(); j++)
+	std::complex<PRISMATIC_FLOAT_PRECISION> I = 0.0 + 1.0i;
+	PRISMATIC_FLOAT_PRECISION two = 2.0;
+	for(auto jj = 0; jj < qya.get_dimj(); jj++)
 	{
-		for(auto i = 0; i < qya.get_dimi(); i++)
+		for(auto ii = 0; ii < qya.get_dimi(); ii++)
 		{
-			qyShift.at(j,i) = -2.0*i*pi*qya.at(j,i);
-			qxShift.at(j,i) = -2.0*i*pi*qxa.at(j,i);
+			qyShift.at(jj,ii) = -two*I*pi*qya.at(jj,ii);
+			qxShift.at(jj,ii) = -two*I*pi*qxa.at(jj,ii);
 		}
 	}
 

--- a/src/PRISM03_calcOutput.cpp
+++ b/src/PRISM03_calcOutput.cpp
@@ -194,7 +194,6 @@ void createStack_integrate(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 void setupFourierCoordinates(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 {
 	// create Fourier space coordinates
-
 	pars.qxaReduce = array2D_subset(pars.qxaOutput,
 									0, pars.meta.interpolationFactorY, pars.qxaOutput.get_dimj(),
 									0, pars.meta.interpolationFactorX, pars.qxaOutput.get_dimi());

--- a/src/PRISM03_calcOutput.cu
+++ b/src/PRISM03_calcOutput.cu
@@ -46,7 +46,6 @@ namespace Prismatic {
 		
 		for (auto j = 0; j < total_num_streams; ++j) {
 			cudaSetDevice(j % pars.meta.numGPUs);
-			std::cout << &cuda_pars.streams[j] << std::endl;
 			cudaErrchk(cudaStreamCreate(&cuda_pars.streams[j]));
 			cufftErrchk(cufftPlan2d(&cuda_pars.cufftPlans[j], pars.imageSizeReduce[0], pars.imageSizeReduce[1], PRISMATIC_CUFFT_PLAN_TYPE));
 			cufftErrchk(cufftSetStream(cuda_pars.cufftPlans[j], cuda_pars.streams[j]));

--- a/src/PRISM03_calcOutput.cu
+++ b/src/PRISM03_calcOutput.cu
@@ -41,7 +41,6 @@ namespace Prismatic {
 		const int total_num_streams = pars.meta.numGPUs * pars.meta.numStreamsPerGPU;
 
 		// create CUDA streams and cuFFT plans
-		std::cout << "total num streams" << total_num_streams << std::endl;
 		cuda_pars.streams = new cudaStream_t[total_num_streams];;
 		cuda_pars.cufftPlans = new cufftHandle[total_num_streams];
 		

--- a/src/PRISM_entry.cpp
+++ b/src/PRISM_entry.cpp
@@ -208,8 +208,6 @@ void PRISM_series_runFP(Parameters<PRISMATIC_FLOAT_PRECISION> &pars, size_t fpNu
 		PRISM02_calcSMatrix(pars);
 	}
 
-
-
 	for(auto i = 0; i < pars.meta.seriesVals[0].size(); i++)
 	{
 		std::cout << "------------------- Series iter " << i << " -------------------" << std::endl;

--- a/src/PRISM_entry.cpp
+++ b/src/PRISM_entry.cpp
@@ -58,7 +58,6 @@ Parameters<PRISMATIC_FLOAT_PRECISION> PRISM_entry(Metadata<PRISMATIC_FLOAT_PRECI
 
 		for(auto i = 0; i < prismatic_pars.meta.seriesTags.size(); i++)
 		{
-			std::cout << "writing output for series iter " << i << std::endl;
 			std::string currentName = prismatic_pars.meta.seriesTags[i];
 			prismatic_pars.currentTag = currentName;
 			prismatic_pars.meta.probeDefocus = prismatic_pars.meta.seriesVals[0][i]; //TODO: later, if expanding sim series past defocus, need to pull current val more generally

--- a/src/aberration.cpp
+++ b/src/aberration.cpp
@@ -111,7 +111,6 @@ Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> getChi(Array2D<PRISMATIC_FLOAT_
 
     Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> chi = zeros_ND<2, std::complex<PRISMATIC_FLOAT_PRECISION>>({{q.get_dimj(), q.get_dimi()}});
 	const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
-	std::cout << "number of aberrations: " << ab.size() << std::endl;
     for(auto n = 0; n < ab.size(); n++)
     {
         for(auto j = 0; j < chi.get_dimj(); j++)

--- a/src/aberration.cpp
+++ b/src/aberration.cpp
@@ -114,7 +114,7 @@ Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> getChi(Array2D<PRISMATIC_FLOAT_
 	std::cout << "number of aberrations: " << ab.size() << std::endl;
     for(auto n = 0; n < ab.size(); n++)
     {
-        for(auto j = 0; j < chi.get_dimi(); j++)
+        for(auto j = 0; j < chi.get_dimj(); j++)
         {
             for(auto i = 0; i < chi.get_dimi(); i++)
             {

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -1122,6 +1122,11 @@ void writeMetadata(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 	writeScalarAttribute(sim_params, "C", (int) pars.meta.alsoDoCPUWork);
 
 	//create scalar float attributes
+	//overwrite NaNs to zero for C1, C3, C5
+	if(isnan(pars.meta.probeDefocus)) pars.meta.probeDefocus = 0.0;
+	if(isnan(pars.meta.C3)) pars.meta.C3 = 0.0;
+	if(isnan(pars.meta.C5)) pars.meta.C5 = 0.0;
+
 	writeScalarAttribute(sim_params, "px", pars.meta.realspacePixelSize[1]);
 	writeScalarAttribute(sim_params, "py", pars.meta.realspacePixelSize[0]);
 	writeScalarAttribute(sim_params, "P", pars.meta.potBound);
@@ -2091,6 +2096,7 @@ void updateScratchData(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 	//for series simulations, need to update the 3D output array independently with a read-add-write process
 	Array4D<PRISMATIC_FLOAT_PRECISION> tmp_buffer(pars.output);
 	std::string currentName = pars.currentTag;
+
 	std::cout << "Reading scratch dataset " << currentName << " from " <<  "prismatic_scratch.h5" << std::endl;
 	readRealDataSet_inOrder(tmp_buffer, "prismatic_scratch.h5", "scratch/"+currentName);
 	for(auto i = 0; i < pars.output.size(); i++) tmp_buffer[i] += pars.output[i];

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -515,7 +515,7 @@ void setupHRTEMOutput(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 	for(auto i = 0; i < xTilts_write.size(); i++)
 	{
 		dim_tilts.at(i,0) = xTilts_write[i];
-		dim_tilts.at(i,0) = yTilts_write[i];
+		dim_tilts.at(i,1) = yTilts_write[i];
 	}
 	
 	writeRealDataSet_inOrder(hrtem_group, "dim1", &x_dim_data[0], x_size, 1);
@@ -880,7 +880,7 @@ void saveHRTEM(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 				for(auto k = 0; k < pars.Scompact.get_dimk(); k++)
 				{
 					//scale S matrix to mean value and restride
-					output_buffer.at(i,j,k) = pars.Scompact.at(k,j,i)*scale;
+					output_buffer.at(i,j,pars.HRTEMbeamOrder[k]) = pars.Scompact.at(k,j,i)*scale;
 				}
 			}
 		}

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -593,7 +593,7 @@ void setupHRTEMOutput_virtual(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 		dest_offset[3] = pars.yTiltsInd_tem[i];
 		vds_mspace.selectHyperslab(H5S_SELECT_SET, dest_mdims, dest_offset);
 
-		plist.setVirtual(vds_mspace, src_data.getFileName(), src_path, src_mspace);
+		plist.setVirtual(vds_mspace, ".", src_path, src_mspace);
 	}
 
 	dest_offset[2] = 0;
@@ -1772,7 +1772,7 @@ void writeVirtualDataSet(H5::Group group,
 		for(auto j = rank; j < rank+new_rank; j++) offset[j] = indices[i][j-rank];
 		
 		vds_mspace.selectHyperslab(H5S_SELECT_SET, mdims_ind, offset);
-		plist.setVirtual(vds_mspace, datasets[i].getFileName(), path, src_mspace);
+		plist.setVirtual(vds_mspace, ".", path, src_mspace);
 	}
 
 	for(auto i = rank; i < rank+new_rank; i++) offset[i] = 0;

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -543,7 +543,6 @@ void setupHRTEMOutput(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 void setupHRTEMOutput_virtual(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 {
 	H5::Group datacubes = pars.outputFile.openGroup("4DSTEM_simulation/data/datacubes");
-
 	//get unique vectors for qx and qy first; assumes sorting before set up
 	std::vector<PRISMATIC_FLOAT_PRECISION> xTilts_unique = getUnique(pars.xTilts_tem);
 
@@ -880,7 +879,7 @@ void saveHRTEM(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 				for(auto k = 0; k < pars.Scompact.get_dimk(); k++)
 				{
 					//scale S matrix to mean value and restride
-					output_buffer.at(i,j,pars.HRTEMbeamOrder[k]) = pars.Scompact.at(k,j,i)*scale;
+					output_buffer.at(i,j,k) = pars.Scompact.at(pars.HRTEMbeamOrder[k],j,i)*scale;
 				}
 			}
 		}

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -543,8 +543,11 @@ void setupHRTEMOutput(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 void setupHRTEMOutput_virtual(Parameters<PRISMATIC_FLOAT_PRECISION> &pars)
 {
 	H5::Group datacubes = pars.outputFile.openGroup("4DSTEM_simulation/data/datacubes");
-	//get unique vectors for qx and qy first; assumes sorting before set up
-	std::vector<PRISMATIC_FLOAT_PRECISION> xTilts_unique = getUnique(pars.xTilts_tem);
+
+	//get unique vectors for qx and qy first
+	std::vector<PRISMATIC_FLOAT_PRECISION> xTilts_unique(pars.xTilts_tem);
+	std::sort(xTilts_unique.begin(), xTilts_unique.end());
+	xTilts_unique = getUnique(xTilts_unique);
 
 	std::vector<PRISMATIC_FLOAT_PRECISION> yTilts_unique(pars.yTilts_tem);
 	std::sort(yTilts_unique.begin(), yTilts_unique.end());


### PR DESCRIPTION
Bug fixes:
- HRTEM beam ordering fix-> previously, sorting did not work for multiple FP
- Frozen Phonon random number generators changed to be spawned per thread for both 2D and 3D potential integration and now use a mersenne twister-> should be more stable and secure than the previous generator configuration
- Fix virtual datasets to point to self file instead of relative filepath to self
-  Changed scheme for integrating defocus, C3, and C5 inputs into dimensionless aberration so that they are read and updated correctly

Performance change:
- Apply HRTEM aberrations in propBack propagator instead of separately on CPU

New Feature:
- Fourier space arrays are now saved automatically when running HRTEM simulations