### PR TITLE
Flip coordinates in crop routine

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -164,14 +164,14 @@ Array2D<T> cropOutput(Array2D<T> &img, const Parameters<T> &pars){
     Array2D<T> shifted = circShift(img,qyInd_max,qxInd_max);
 
     //construct cropped return image
-    Array2D<T> cropped = zeros_ND<2, T>({{qyInd_max*2, qxInd_max*2}});
+    Array2D<T> cropped = zeros_ND<2, T>({{qxInd_max*2, qyInd_max*2}});
 
     //copy data to return array
     for(auto j = 0; j < cropped.get_dimj(); j++)
     {
         for(auto i = 0; i < cropped.get_dimi(); i++)
         {
-            cropped.at(j,i) = shifted.at(j,i);
+            cropped.at(i,j) = shifted.at(j,i);
         }
     }
     
@@ -212,14 +212,14 @@ Array2D<std::complex<T>> cropOutput(Array2D<std::complex<T>> &img, const Paramet
     Array2D<std::complex<T>> shifted = circShift(img,qyInd_max,qxInd_max);
 
     //construct cropped return image
-    Array2D<std::complex<T>> cropped = zeros_ND<2, std::complex<T>>({{qyInd_max*2, qxInd_max*2}});
+    Array2D<std::complex<T>> cropped = zeros_ND<2, std::complex<T>>({{qxInd_max*2, qyInd_max*2}});
 
     //copy data to return array
     for(auto j = 0; j < cropped.get_dimj(); j++)
     {
         for(auto i = 0; i < cropped.get_dimi(); i++)
         {
-            cropped.at(j,i) = shifted.at(j,i);
+            cropped.at(i,j) = shifted.at(j,i);
         }
     }
     


### PR DESCRIPTION
Similar issue to last pull, fixing some coordinate issues with the output for rectangular CBED outputs when using the 4D cropping feature