### PR TITLE
Fixes to get 2.0 building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(PRISM)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE RELEASE)
 
+cmake_policy(SET CMP0074 NEW)
+
 # set warning level
 if ( CMAKE_COMPILER_IS_GNUCC )
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w -O3 -fPIC -g")
@@ -196,7 +198,7 @@ if (PRISMATIC_ENABLE_CLI)
 endif (PRISMATIC_ENABLE_CLI)
 
 if(APPLE)
-  list(APPEND GUI_SOURCE_FILES ../Qt/icons/prismatic-icon.icns)
+  # list(APPEND GUI_SOURCE_FILES ../Qt/icons/prismatic-icon.icns)
   set(MACOSX_BUNDLE_ICON_FILE prismatic-icon.icns)
   set(MACOSX_BUNDLE_BUNDLE_VERSION 0.1)
   set_source_files_properties(../Qt/icons/prismatic-icon.icns PROPERTIES

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -359,7 +359,7 @@ void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 
 	Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> qyShift = zeros_ND<2,std::complex<PRISMATIC_FLOAT_PRECISION>>({{qya.get_dimj(), qya.get_dimi()}});
 	Array2D<std::complex<PRISMATIC_FLOAT_PRECISION>> qxShift = zeros_ND<2,std::complex<PRISMATIC_FLOAT_PRECISION>>({{qya.get_dimj(), qya.get_dimi()}});
-	std::complex<PRISMATIC_FLOAT_PRECISION> I = 0.0 + 1.0i;
+	std::complex<PRISMATIC_FLOAT_PRECISION> I (0.0, 1.0);
 	PRISMATIC_FLOAT_PRECISION two = 2.0;
 	for(auto jj = 0; jj < qya.get_dimj(); jj++)
 	{


### PR DESCRIPTION
I had to make a tweak to how cmake handles the icon file and how it accepts command line hints for libraries to get it to generate the makefile. (Likely the second problem is just on my machine, since I have a million versions of every library Prismatic needs and I need to be able to hint the right prefixes.)

There is also a change in PRISM01_calcPotentials.cpp, to the construction of the imaginary unit `I`, which threw an error. Maybe I am using a newer version of C++, maybe it's because I am using clang, I'm not sure...

Leaving this as a draft for right now as there are still some bugs with the build, and if it's something I can resolve easily myself I'll do those.