### PR TITLE
BUGFIX: `meta.maxFileSize` is given in GB.

### DIFF
--- a/include/params.h
+++ b/include/params.h
@@ -427,7 +427,7 @@ namespace Prismatic{
 
 		if(meta.savePotentialSlices) numElems += imageSize[0]*imageSize[1]*std::ceil(tiledCellDim[0]/meta.sliceThickness);
 		std::cout << "Approximate output file size is (Gb): " << (numElems*sizeof(PRISMATIC_FLOAT_PRECISION))/(1e9) << std::endl;
-		if(numElems*sizeof(PRISMATIC_FLOAT_PRECISION) > meta.maxFileSize)
+		if(numElems*sizeof(PRISMATIC_FLOAT_PRECISION)/(1e9) > meta.maxFileSize)
 		{
 			throw std::runtime_error("Simulation output file will be larger than maximum allowed file size.");
 		}


### PR DESCRIPTION
``--max_filesize`` should be given in GB according to docs but is later used in bytes and gives the following error when ``--max_filesize:10`` is set.
```bash
Execution plan: PRISM
extracted 25 atoms from 27 lines in CeTiO3_210.xyz
Approximate output file size is (Gb): 6.1201
Prismatic: Error with requested simulation settings.
Simulation output file will be larger than maximum allowed file size.
Terminating
```



Signed-off-by: Ivo Alxneit <ivo.alxneit@psi.ch>