### PR TITLE
fix NameError in process.py

### DIFF
--- a/pyprismatic/process.py
+++ b/pyprismatic/process.py
@@ -233,6 +233,6 @@ def source_size(data, rx, ry, sigma):
     rxx = rxx-rx[len(rx)//2-1]
     ryy = ryy-ry[len(ry)//2-1]
     rr = np.sqrt(rxx**2.0 + ryy**2.0)
-    source_size_kernel = rad_gaussian(rr, kernel_sigma)
+    source_size_kernel = rad_gaussian(rr, sigma)
     
     return signal.convolve2d(data, source_size_kernel, 'same')/signal.convolve2d(np.ones(np.shape(data)), source_size_kernel, 'same')


### PR DESCRIPTION
When trying to run  the example notebooks I ran into this error, with the source_size function seems the  kernel_sigma should  just be sigma:
 
NameError                                 Traceback (most recent call last)
../postprocess_final.ipynb Cell 4 line 4
      2 kernel_sigma = 0.8/2.355 #80pm FWHM
      3 haadf_img = np.sum(vd.data[:,:,40:],axis=2)
----> 4 ss = source_size(haadf_img, rx, ry, sigma=kernel_sigma) 
      5 shot = apply_poisson_noise_STEM(ss, dose=dose)

File ../site-packages/pyprismatic/process.py:236, in source_size(data, rx, ry, sigma)
    234 ryy = ryy-ry[len(ry)//2-1]
    235 rr = np.sqrt(rxx**2.0 + ryy**2.0)
--> 236 source_size_kernel = rad_gaussian(rr, kernel_sigma)
    238 return signal.convolve2d(data, source_size_kernel, 'same')/signal.convolve2d(np.ones(np.shape(data)), source_size_kernel, 'same')

NameError: name 'kernel_sigma' is not defined